### PR TITLE
fix 404 page styling overwrites and move styling

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -3,22 +3,8 @@ permalink: /404.html
 layout: default
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
-
-<div class="container">
-  <h1>404</h1>
+<div id="error-content">
+  <h1 id="error-title">404</h1>
 
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>

--- a/docs/assets/css/styles.scss
+++ b/docs/assets/css/styles.scss
@@ -278,3 +278,16 @@ li.list-active a {
     color: $mid-purple;
     text-decoration: underline;
 }
+
+// 404 page styling
+#error-content {
+    margin: 10px auto;
+    max-width: 600px;
+    text-align: center;
+  }
+  #error-title {
+    margin: 30px 0;
+    font-size: 4em;
+    line-height: 1;
+    letter-spacing: -1px;
+  }

--- a/docs/assets/css/styles.scss
+++ b/docs/assets/css/styles.scss
@@ -285,9 +285,9 @@ li.list-active a {
     max-width: 600px;
     text-align: center;
   }
-  #error-title {
+#error-title {
     margin: 30px 0;
     font-size: 4em;
     line-height: 1;
     letter-spacing: -1px;
-  }
+}


### PR DESCRIPTION
### Summary

Fix 404 page footer variances from other pages. Move styling from inline styling to main stylesheet. 

### Reason

Footer on 404 page was different from rest of the site due to inline styling. 
