### PR TITLE
Fix OpenAPI capitalisation

### DIFF
--- a/docs/_data/main-nav.yaml
+++ b/docs/_data/main-nav.yaml
@@ -44,7 +44,7 @@ toc:
         url: /insomnia/design-documents
       - title: Linting
         url: /insomnia/linting
-      - title: GraphQL for openAPI
+      - title: GraphQL for OpenAPI
         url: /insomnia/graphql-for-openapi
       - title: Live Preview
         url: /insomnia/live-preview

--- a/docs/insomnia/graphql-for-openapi.md
+++ b/docs/insomnia/graphql-for-openapi.md
@@ -1,6 +1,6 @@
 ---
 layout: article-detail
-title:  GraphQL for openAPI
+title:  GraphQL for OpenAPI
 category: "API Design"
 category-url: api-design
 ---


### PR DESCRIPTION
### Summary

👋 Thanks for these docs! This is a small fix to change the article title from `GraphQL for openAPI` to `GraphQL for OpenAPI`

### Reason

OpenAPI starts with a capital 'O' https://en.wikipedia.org/wiki/OpenAPI_Specification

### Testing

Build and test with `bundle exec jekyll serve`.
