### PR TITLE
Fix Linux install snippet.

### DIFF
--- a/docs/insomnia/install.md
+++ b/docs/insomnia/install.md
@@ -35,7 +35,7 @@ There are many distributions of Linux in the world. Insomnia should be able to r
 There is a Debian package apt repository that can be added and installed using apt-get. You can also manually download the latest debian package here.
 
 ```bash
-Add to sources
+# Add to sources
 echo "deb [trusted=yes arch=amd64] https://download.konghq.com/insomnia-ubuntu/ default all" \
     | sudo tee -a /etc/apt/sources.list.d/insomnia.list
 


### PR DESCRIPTION
### Summary
There is a line in the Linux install snippet that is meant to be a comment, but does not begin with a hash. This change just adds the missing hash.

### Reason
This PR is to resolve a simple typo, therefore there is no corresponding ticket. The discrepancy may confuse some users.

### Testing
Ensure that the first line of the Linux install script begins with a hash (`#`).
