### PR TITLE
Rework Import and Export Data page

### DIFF
--- a/docs/assets/css/styles.scss
+++ b/docs/assets/css/styles.scss
@@ -270,6 +270,12 @@ p {
     }
 }
 
+.col-md-7 {
+    h2, h3, h4 {
+        padding-top: 30px;
+    }
+}
+
 .form-inline {
     margin-left: 20px;
 }

--- a/docs/insomnia/context-object-reference.md
+++ b/docs/insomnia/context-object-reference.md
@@ -7,6 +7,45 @@ category-url: plugins
 
 This document is a context object reference. 
 
+## context.request
+
+```
+// context.request functions
+type RequestContext = {
+    getId (): string,
+    getName (): string,
+    getUrl (): string,
+    setUrl (url: string): void,
+    getMethod (): string,
+    getHeaders (): Array<{ name: string, value: string }>,
+    getHeader (name: string): string | null, 
+    hasHeader (name: string): boolean,
+    removeHeader (name: string): void,
+    setHeader (name: string, value: string): void,
+    addHeader (name: string, value: string): void,
+    getParameter (name: string): string | null,
+    getParameters (): Array<{name: string, value: string}>,
+    setParameter (name: string, value: string): void,
+    hasParameter (name: string): boolean,
+    addParameter (name: string, value: string): void,
+    removeParameter (name: string): void,
+    setBodyText (text: string): void,
+    getBodyText (): string,
+    setCookie (name: string, value: string): void,
+    getEnvironmentVariable (name: string): any,
+    getEnvironment (): Object,
+    setAuthenticationParameter (string: any): void,
+    getAuthentication (): Object,
+    setCookie (name: string, value: string): void,
+    settingSendCookies (enabled: boolean): void,
+    settingStoreCookies (enabled: boolean): void,
+    settingEncodeUrl (enabled: boolean): void,
+    settingDisableRenderRequestBody (enabled: boolean): void,
+};
+```
+
+Example: Set Content-Type header on every POST request
+
 ## context.response
 
 ```
@@ -22,8 +61,9 @@ getHeader (name: string): string | Array<string> | null
 hasHeader (name: string): boolean
 ```
 
-```
 Example: Save response to file
+
+```
 const fs = require('fs');
 
 // Request hook to save response to file
@@ -50,6 +90,7 @@ async all(): Promise<Array<{ key: string, value: string }>>
 ```
 
 ## context.app
+
 The app context contains a general set of helpers that are global to the application.
 
 ```

--- a/docs/insomnia/import-export-data.md
+++ b/docs/insomnia/import-export-data.md
@@ -5,233 +5,33 @@ category: "Get Started"
 category-url: get-started
 ---
 
-Insomnia supports the ability to import multiple file types. Right now, the supported formats are Insomnia, Postman v2, HAR, OpenAPI, Swagger, WSDL, and Curl.
+Insomnia supports importing and exporting. Currently, the supported import formats are Insomnia, Postman v2, HAR, OpenAPI, Swagger, WSDL, and cURL.
 
-To import of export data, go to **Preferences**, then the **Data** tab. 
+To import or export data, go to **Preferences**, then the **Data** tab. 
 
 ![The Data tab in Preferences allows you to import or export data via dropdown options.](/assets/images/import-export-data.png)
 _The Data tab in Preferences allows you to import or export data via dropdown options._
 
-## Export Format Specification
+## Export Special Resources and Resource Types
 
-The following outlines the export format specification. 
+The following outlines special resource IDs, used to map to data, and resource types, used to outline what's included and excluded from an export file. 
 
 {:.alert .alert-primary}
-**Note**: The [Insomnia Importers Package](https://github.com/kong/insomnia/tree/develop/packages/insomnia-importers) has support for migrating older export versions to the latest, as well as supporting external formats like HAR, Postman, Swagger/OpenAPI, and Curl. If you want to contribute new formats, feel free to submit a pull request to the insomnia-importers package of Insomnia.
+**Note**: The [Insomnia Importers Package](https://github.com/kong/insomnia/tree/develop/packages/insomnia-importers) has support for migrating older export versions to the latest, as well as supporting external formats like HAR, Postman, Swagger/OpenAPI, and Curl. If you want to contribute new formats, feel free to submit a pull request to the [insomnia-importers](https://www.npmjs.com/package/insomnia-importers) NPM package.
 
-```
-Root Export Object
-{
-  "_type": "export",
-  "__export_format": 3,
-  "__export_date": "2017-01-10T23:15:55.928Z",
-  "__export_source": "insomnia.desktop.app:v4.0.13",
-  "resources": [{
-    "_type": "request",
-    "url": "https://google.com"
-  }, {
-    "...": "..."
-  }]
-}
-```
+### Special Resource IDs
+
+Special resource IDs are used to map to data in an active workspace. They look like variables within the export file. Some example special resource IDs are:
 
 {:.table .table-striped}
-Key | Description
----- | ---------
-_type | Only possible value currently is export
-__export_format | Specifies the data schema of the export
-__export_data | ISO timestamp of the time of export
-resources | All exported resources (see below for resource types)
-
-```
-Common Resource Properties
-{
-  "_type": "resource_type",
-  "_id": "type_111",
-  "parentId": "type_4567",
-  "created": 1484090000356,
-  "modified": 1484090000356,
-  "...": "..."
-}
-```
-
-{:.table .table-striped}
-Key | Description
----- | ---------
-_type | See below sections for possible resource types
-_id | Id representing the resource
-parentID | Resource ID of parent object (folder or workspace)
-created | When the resource was created
-modified | When the resource was last modified
-
-Special Resource IDs
-__WORKSPACE_ID__
-Maps to the ID of the currently active workspace
-
-__BASE_ENVIRONMENT_ID__
-Maps to the ID of the active workspace’s base environment
-
-__<NAME>_<NUMBER>__
-Any value matching this format will deterministically generate a new ID at import time.
-
-```
-[{
-  "_type": "workspace",
-  "_id": "__WORKSPACE_1__"
-}, {
-  "_type": "request",
-  "_id": "__REQUEST_1__",
-  "parentId": "__WORKSPACE_1__"
-}]
-```
+Resource ID | Description
+----------- | -----------
+`__WORKSPACE_ID__` | Maps to the ID of the currently active workspace
+`__BASE_ENVIRONMENT_ID__` | Maps to the ID of the active workspace base environment
+`__<NAME>_<NUMBER>__` |  Any value matching this format will deterministically generate a new ID at import time
 
 ## Resource Types
-These are the possible resource types that can be imported/exported.
 
-* workspace
-* environment
-* request_group
-* request
+We offer a variety of resource types. Resource types outline what is included and excluded from an export file. Some responses and metadata models aren't exported.
 
-### Resource Type: workspace
-
-```
-{
-  "_type": "workspace",
-  "_id": "__WORKSPACE_ID__",
-  "parentId": null,
-  "created": 1484090000356,
-  "modified": 1484090000356,
-  "name": "My API Project",
-  "description": "This the API for https://api.insomnia.rest/"
-}
-```
-
-{:.table .table-striped}
-Key | Description
----- | ---------
-name | Name of workspace
-description | Plain text description of workspace
-Resource Type | environment
-
-```
-{
-  "_type": "environment",
-  "_id": "__ENVIRONMENT_1__",
-  "parentId": "__WORKSPACE_ID__",
-  "name": "Development",
-  "data": {
-    "base_url": "https://insomnia.rest",
-    "user_id": "user_123",
-    "...": "..."
-  }
-}
-```
-
-{:.table .table-striped}
-Key | Description
----- | ---------
-name | Name of environment
-data{} | User-defined data representing the environment
-Resource Type | request_group
-
-```
-{
-  "_type": "request_group",
-  "_id": "__FOLDER_2__",
-  "name": "New Folder",
-  "parentId": "__FOLDER_1__",
-  "created": 1484090000356,
-  "modified": 1484090000356,
-  "metaSortKey": 1,
-  "environment": {
-    "url": "{{ base_url }}/my/awesome/path",
-    "...": "..."
-  }
-}
-```
-
-{:.table .table-striped}
-Key | Description
----- | ---------
-name | Name of the folder
-metaSortKey | Sort priority relative to its siblings
-environment |  User-defined environment override data
-Resource Type | request
-
-```
-{
-  "_type": "request",
-  "_id": "__REQUEST_1__",
-  "parentId": "__FOLDER_2__",
-  "created": 1484090000356,
-  "modified": 1484090000356,
-  "name": "My Request",
-  "method": "POST",
-  "url": "https://insomnia.rest/foo/bar",
-  "body": {
-    "mimeType": "multipart/form-data",
-    "text": "",
-    "params": [{
-      "type": "file",
-      "name": "my_file",
-      "fileName": "/home/amy/hello.txt",
-      "disabled": false
-    }, {
-      "type": "text",
-      "name": "foo",
-      "value": "bar",
-      "disabled": false
-    }, {
-      "type": "text",
-      "name": "blah",
-      "value": "bar",
-      "disabled": true
-    }]
-  },
-  "parameters": [{
-    "name": "limit",
-    "value": "10",
-    "disabled": false
-  }],
-  "headers": [{
-    "name": "Content-Type",
-    "value": "application/json",
-    "disabled": false
-  }],
-  "authentication": {
-    "username": "User",
-    "password": "Pass"
-  },
-  "metaSortKey": 10
-}
-```
-
-{:.table .table-striped}
-Key | Description
----- | ---------
-name | Name of the request
-metaSortKey | Sort priority relative to its siblings
-method | Request method (GET, POST, …).
-url | Absolute URL of the request
-body{} | Body of the request
-mimeType | Mime type of posted data
-text | Plain text posted data
-fileName | File path to binary body
-params[] | List of form parameter objects
-name | Name of the parameter
-type | Either text or file
-value | Value of the parameter
-fileName | File path of param
-disabled | If true, the entry will be ignored
-parameters[] | Array of URL query parameters
-name | Name of parameter
-value | Value of parameter
-disabled | If true, the entry will be ignored
-headers[] | Array of HTTP header objects
-name | Name of parameter
-value | Value of parameter
-disabled | If true, the entry will be ignored
-authentication{} | HTTP authentication (currently only basic auth supported)
-username | Username for HTTP Basic Auth
-password | Password for HTTP Basic Auth
+See all resource types listed under [data.resources](https://github.com/Kong/insomnia/blob/7abde2a01700f587179941b3231fb1078fcb1e41/packages/insomnia-app/app/common/export.ts#L185-L198). 

--- a/docs/insomnia/template-tags.md
+++ b/docs/insomnia/template-tags.md
@@ -31,8 +31,6 @@ The request tag is useful for referencing values from the request that is curren
 ## Sample Template Tags
 As mentioned, a custom Template Tag can be added, which can then be referenced inside Insomnia’s template system to render custom values.
 
-Custom actions on template tags will be available early 2021.
-
 ```
 type RenderContext = {
   // API not finalized yet
@@ -100,9 +98,12 @@ module.exports.templateTags = [{
         return Math.round(min + Math.random() * (max - min));
     }
 }];
-Request/Response Hooks
+```
+
+### Request/Response Hooks
 Plugins can implement “hook” functions that get called when certain things happen. A plugin can currently export two different types of hooks:
 
+```
 type RequestContext = {
     app: AppContext,            // Defined Below
     request: RequestContext     // Defined Below
@@ -112,14 +113,19 @@ type ResponseContext = {
     app: AppContext,            // Defined Below
     response: ResponseContext   // Defined below
 }
+```
 
+```
 // Hooks are exported as an array of "hook" functions which get 
 // called with the appropriate plugin API context.
 module.exports.requestHooks = Array<(context: RequestContext) => void>
 module.exports.responseHooks = Array<(context: ResponseContext) => void>
-Request Actions
+```
+
+### Request Actions
 Actions can be added to the bottom of the request dropdown by defining a request action plugin.
 
+```
 type RequestAction = {
     label: string,
     action: (context: Context, { 
@@ -129,14 +135,20 @@ type RequestAction = {
     label: string,
     icon?: string,
 };
+```
 
+```
 // Request actions are exported as an array of objects
 module.exports.requestActions = Array<RequestAction>
 Example: Plugin to get request details in a modal
 Example: Send request
-Folder Actions
+```
+
+### Folder Actions
+
 Actions can be added to the bottom of the folder dialog by defining a folder (request group) action plugin.
 
+```
 type RequestGroupAction = {
     label: string,
     action: (context: Context, { 
@@ -144,13 +156,19 @@ type RequestGroupAction = {
         requests: Array<Request>
     }): Promise<void>
 };
+```
 
+```
 // Folder actions are exported as an array of objects
 module.exports.requestGroupActions = Array<RequestGroupAction>
 Example: Plugin to send all requests in a folder
-Workspace Actions
+```
+
+### Workspace Actions
+
 Actions can be added to the main app dropdown by defining a workspace action plugin.
 
+```
 type WorkspaceAction = {
     label: string,
     action: (context: Context, { 
@@ -165,9 +183,13 @@ type WorkspaceAction = {
 // Workspace actions are exported as an array of objects
 module.exports.workspaceActions = Array<WorkspaceAction>
 Example: Plugin to export the current workspace
-Custom Themes
+```
+
+### Custom Themes
+
 Additional color schemes can be created an installed via the plugin system. A good place to start is to view the bundled themes within the insomnia-plugin-themes module.
 
+```
 type ThemeBlock = {
   background?: {
     default?: string,
@@ -256,5 +278,3 @@ type RequestContext = {
 };
 Example: Set Content-Type header on every POST request
 ```
-
-

--- a/docs/insomnia/template-tags.md
+++ b/docs/insomnia/template-tags.md
@@ -71,7 +71,10 @@ type TemplateTag = {
     run?: (context) => Promise<void>,
   }>,
 };
-Example: Template tag to generate random number
+```
+
+### Example: Template tag to generate random number
+```
 /**
  * Example template tag that generates a random number 
  * between a user-provided MIN and MAX
@@ -100,7 +103,7 @@ module.exports.templateTags = [{
 }];
 ```
 
-### Request/Response Hooks
+## Request/Response Hooks
 Plugins can implement “hook” functions that get called when certain things happen. A plugin can currently export two different types of hooks:
 
 ```
@@ -122,7 +125,7 @@ module.exports.requestHooks = Array<(context: RequestContext) => void>
 module.exports.responseHooks = Array<(context: ResponseContext) => void>
 ```
 
-### Request Actions
+## Request Actions
 Actions can be added to the bottom of the request dropdown by defining a request action plugin.
 
 ```
@@ -140,11 +143,12 @@ type RequestAction = {
 ```
 // Request actions are exported as an array of objects
 module.exports.requestActions = Array<RequestAction>
-Example: Plugin to get request details in a modal
-Example: Send request
 ```
 
-### Folder Actions
+Example: Plugin to get request details in a modal
+Example: Send request
+
+## Folder Actions
 
 Actions can be added to the bottom of the folder dialog by defining a folder (request group) action plugin.
 
@@ -161,10 +165,11 @@ type RequestGroupAction = {
 ```
 // Folder actions are exported as an array of objects
 module.exports.requestGroupActions = Array<RequestGroupAction>
-Example: Plugin to send all requests in a folder
 ```
 
-### Workspace Actions
+Example: Plugin to send all requests in a folder
+
+## Workspace Actions
 
 Actions can be added to the main app dropdown by defining a workspace action plugin.
 
@@ -182,12 +187,13 @@ type WorkspaceAction = {
 ```
 // Workspace actions are exported as an array of objects
 module.exports.workspaceActions = Array<WorkspaceAction>
-Example: Plugin to export the current workspace
 ```
 
-### Custom Themes
+Example: Plugin to export the current workspace
 
-Additional color schemes can be created an installed via the plugin system. A good place to start is to view the bundled themes within the insomnia-plugin-themes module.
+## Custom Themes
+
+Additional color schemes can be created an installed via the plugin system. A good place to start is to view the bundled themes within the [insomnia-plugin-themes](https://github.com/Kong/insomnia/tree/develop/plugins/insomnia-plugin-core-themes) module.
 
 ```
 type ThemeBlock = {
@@ -240,41 +246,7 @@ type ThemeInner = {
     transparentOverlay?: ThemeBlock,
   },
 };
+```
 Example: Simple dark theme
 Example: Styling sub-components
 Example: Custom CSS
-context.request
-// context.request functions
-type RequestContext = {
-    getId (): string,
-    getName (): string,
-    getUrl (): string,
-    setUrl (url: string): void,
-    getMethod (): string,
-    getHeaders (): Array<{ name: string, value: string }>,
-    getHeader (name: string): string | null, 
-    hasHeader (name: string): boolean,
-    removeHeader (name: string): void,
-    setHeader (name: string, value: string): void,
-    addHeader (name: string, value: string): void,
-    getParameter (name: string): string | null,
-    getParameters (): Array<{name: string, value: string}>,
-    setParameter (name: string, value: string): void,
-    hasParameter (name: string): boolean,
-    addParameter (name: string, value: string): void,
-    removeParameter (name: string): void,
-    setBodyText (text: string): void,
-    getBodyText (): string,
-    setCookie (name: string, value: string): void,
-    getEnvironmentVariable (name: string): any,
-    getEnvironment (): Object,
-    setAuthenticationParameter (string: any): void,
-    getAuthentication (): Object,
-    setCookie (name: string, value: string): void,
-    settingSendCookies (enabled: boolean): void,
-    settingStoreCookies (enabled: boolean): void,
-    settingEncodeUrl (enabled: boolean): void,
-    settingDisableRenderRequestBody (enabled: boolean): void,
-};
-Example: Set Content-Type header on every POST request
-```


### PR DESCRIPTION
### Summary

* rm sample JSON and tables
* Add descriptions for Special Resource IDs and Resource Types
* Fix content (taking headers and text out of code block) on Template Tags page

### Reason

Currently docs had extraneous content and minimal context. 
