### PR TITLE
Add setup instructions and dynamic page title

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Please refer to our [Contributing Guidelines](/CONTRIBUTING.md).
 
 ## Run locally
 
-1. Clone the repository. 
-2. Run `cd docs`.
-3. Run `bundle exec jekyll serve`.
-4. Browse to http://localhost:4000.
+1. Clone the repository.
+2. Install [Ruby](https://www.ruby-lang.org/en/) and [Bundler](https://bundler.io/).
+3. Run `cd docs`.
+4. Run `bundle install`.
+5. Run `bundle exec jekyll serve`.
+6. Browse to http://localhost:4000.

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -3,7 +3,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="og:image" content="{{ '/assets/images/insomnia-docs-share.png' | relative_url }}">
     <link rel="shortcut icon" type="image/svg" href="{{ '/assets/images/insomnia-favicon.svg' | relative_url }}">
-    <title>{{ site.title }}</title>
+    {% if page.title %}
+        <title>{{ page.title }}</title>
+    {% else %}
+        <title>{{ site.title }}</title>
+    {% endif %}
     <!-- Google Font -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -4,7 +4,7 @@
     <meta property="og:image" content="{{ '/assets/images/insomnia-docs-share.png' | relative_url }}">
     <link rel="shortcut icon" type="image/svg" href="{{ '/assets/images/insomnia-favicon.svg' | relative_url }}">
     {% if page.title %}
-        <title>{{ page.title }}</title>
+        <title>{{ page.title }} | {{ site.title }}</title>
     {% else %}
         <title>{{ site.title }}</title>
     {% endif %}


### PR DESCRIPTION
### Summary
This PR ensure the page title in the generated HTML matches the page title of the page being viewed.

### Reason
When sharing links, I noticed that the link preview just says "Insomnia Docs" instead of the title of the page being shared.

<img width="474" alt="image" src="https://user-images.githubusercontent.com/4312346/132621677-5c2079fa-21b5-411c-babe-9a3e684fcaf0.png">

### Testing
Run the website, navigate to it in a browser and view the browser tab as you navigate around the docs.

#### Before:
![2021-09-09 16 03 42](https://user-images.githubusercontent.com/4312346/132621773-6e9bf81e-7441-418d-80c7-753eaebc2ca1.gif)


#### After:
![2021-09-09 16 10 32](https://user-images.githubusercontent.com/4312346/132621788-2e90e4c3-76de-4165-a2bb-51b350c1a645.gif)

(Ignore the misplaced click animations, my gif recording software failed)