### PR TITLE
fix codeblock overflow

### DIFF
--- a/docs/assets/css/styles.scss
+++ b/docs/assets/css/styles.scss
@@ -107,6 +107,7 @@ pre>code {
     display: block;
     padding: 20px;
     border-radius: 5px;
+    overflow-x: auto;
 }
 
 #report-link {


### PR DESCRIPTION
### Summary

Added `overflow-x: auto` to codeblocks to account for overflow issue. 

### Reason

Overflow content was not being handled. 
