### PR TITLE
Add Bitbucket Server auth instructions for Git Sync

### DIFF
--- a/docs/insomnia/git-sync.md
+++ b/docs/insomnia/git-sync.md
@@ -33,6 +33,7 @@ Find instructions on how to create a Personal Access Token on the following plat
 
 * [Github](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 * [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/)
+* [Bitbucket Server](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html)
 * [Gitlab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
 
 Once complete, click **Done** and the repository settings will be persisted for future operations. Author details and token can be updated after if needed.


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Bitbucket Server is another supported git provider and this adds in a reference to where to generate a personal access token, which is different to Bitbucket Cloud.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
It exists in the tooltip in the app, and the docs were outdated

![image](https://user-images.githubusercontent.com/4312346/133229715-59b9f15f-e9ae-4224-aa45-ec196dc37aa9.png)


### Testing
<!-- How can your reviewers test your change? How did you test it? -->
Navigate to https://insomnia-docs-git-add-bitbucket-server-teaminsomnia.vercel.app/insomnia/git-sync#remote-repository-settings