### PR TITLE
Add canonical URL meta tag

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Insomnia Docs: Deliver high quality APIs through standards 
   and collaboration with the Insomnia API design platform.
 baseurl: "/" # the subpath of your site, e.g. /blog
-url: "https://docs.insomnia.rest/" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://docs.insomnia.rest" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: getinsomnia
 github_username:  insomnia
 

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -3,6 +3,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="og:image" content="{{ '/assets/images/insomnia-docs-share.png' | relative_url }}">
     <link rel="shortcut icon" type="image/svg" href="{{ '/assets/images/insomnia-favicon.svg' | relative_url }}">
+    {% if page.url == '/' %}
+    <link rel="canonical" href="{{ site.url }}">
+    {% else %}
+    <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
+    {% endif %}
     {% if page.title %}
         <title>{{ page.title }} | {{ site.title }}</title>
     {% else %}


### PR DESCRIPTION
### Summary
- Adds the canonical URL meta tag to ensure that all google indexed links uses the correct domain/path