### PR TITLE
[DOCU-1824] add Move Collections and Documents Between Projects

### DIFF
--- a/docs/insomnia/projects.md
+++ b/docs/insomnia/projects.md
@@ -17,12 +17,23 @@ There are three types of Projects: Default, Local, and Remote.
 _Projects are available via the main Insomnia dropdown. Here, you will find the Default Project listed first next to the home icon._
 
 ### Default Project
-This is a persistent Project that always exists for all users by default. It cannot be renamed or deleted. It appears next to the home icon in the Projects dropdown menu. 
+
+This is a persistent Project that always exists for all users by default. It cannot be renamed or deleted. It appears next to the home icon in the Projects dropdown menu.
 
 ### Local Project
+
 A local project can be created locally within the application to group Collections and Documents. This only exists on your client, it is not included in any export file, and is not part of your sync data.
 
 ### Remote Project
+
 If you are signed in and have access to a Team with Insomnia Sync enabled, that Team will be represented as a Remote Project on your client. When opening the Projects dropdown, Remote Projects that you have access to will automatically appear in the list.
 
 When creating a Request Collection inside a Remote Project, Insomnia will attempt to automatically enable sync. Collections that have been synced into a Remote Project can be pulled from the Dashboard after activating the Remote Project. For instance, inside the Insomnia Testing remote project, a user can pull Collections.
+
+## Move Collections and Documents Between Projects
+
+At this time, you cannot move a Collection or Document between Projects. However, you can _duplicate_ a Collection or Document into another Project. The duplicate copy will not update if it's modified in one Project.
+
+Duplicate a Collection or Document from the Dashboard by clicking on the three dot menu on a Collection or Document, then select **Duplicate**. A **Duplicate Collection** modal will open. Enter a new name and select the destination Project.
+
+You can also duplicate a Collection or Document from **Editor Mode**. Click on the dropdown arrow next to the Collection or Document name. Click **Collection Settings**. Under **Actions**, click **Duplicate**. Enter a new name and select the destination Project from the modal.


### PR DESCRIPTION
### Summary

Add Move Collections and Documents Between Projects section to Projects page. 

### Reason

We don't explicitly tell users how to move Collections and Documents between Projects. 
