### PR TITLE
Fix submenu link highlighting

### DIFF
--- a/docs/_includes/sidebar-nav.html
+++ b/docs/_includes/sidebar-nav.html
@@ -10,16 +10,17 @@
         <div class="collapse {% for entry in item.items %}{% if page.url contains entry.url %} show {% endif %}{% endfor %}" id="{{ item.collapse-id }}-collapse">
         <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
           {% for entry in item.items %}
-            {% assign currentPage = entry.url | append: '/' %}
-            <li class="doc-link ps-3 pb-1 text-start {% if currentPage == page.url %} list-active {% endif %}">
+            {% assign currentEntry = entry.url | append: '/' %}
+            <li class="doc-link ps-3 pb-1 text-start {% if currentEntry == page.url %} list-active {% endif %}">
               <a href="{{ entry.url }}">
                 {{ entry.title }}
               </a>
-              {% if entry.subfolderitems[0] %}
-              <div class="collapse {% for subentry in entry.subfolderitems %}{% if page.url contains entry.url %} show {% endif %}{% endfor %}" id="{{ subentry.collapse-id }}-collapse">
-                <ul>
+              {% if entry.subfolderitems.size > 0 %}
+              <div class="collapse {% for subentry in entry.subfolderitems %}{% if page.url contains entry.url %} show {% break %}{% endif %}{% endfor %}" id="{{ subentry.collapse-id }}-collapse">
+                <ul class="list-unstyled">
                   {% for subentry in entry.subfolderitems %}
-                    <li class="subentry-link list-unstyled">
+                    {% assign currentSubEntry = subentry.url | append: '/' %}
+                    <li class="doc-link ps-3 pt-1 text-start {% if currentSubEntry == page.url %} list-active {% endif %}">
                       <a href="{{ subentry.url }}">
                         {{ subentry.title }}
                       </a>

--- a/docs/_includes/sidebar-nav.html
+++ b/docs/_includes/sidebar-nav.html
@@ -16,7 +16,7 @@
                 {{ entry.title }}
               </a>
               {% if entry.subfolderitems.size > 0 %}
-              <div class="collapse {% for subentry in entry.subfolderitems %}{% if page.url contains entry.url %} show {% break %}{% endif %}{% endfor %}" id="{{ subentry.collapse-id }}-collapse">
+              <div class="collapse {% for subentry in entry.subfolderitems %}{% if page.url contains entry.url %} show {% break %}{% endif %}{% endfor %}">
                 <ul class="list-unstyled">
                   {% for subentry in entry.subfolderitems %}
                     {% assign currentSubEntry = subentry.url | append: '/' %}

--- a/docs/assets/css/styles.scss
+++ b/docs/assets/css/styles.scss
@@ -185,6 +185,11 @@ li.doc-link {
         color: black;
     }
 
+    &.list-active > a {
+        color: $mid-purple;
+        text-decoration: underline;
+    }
+
     a:hover {
         text-decoration: underline;
     }
@@ -317,11 +322,6 @@ p {
 
 .form-inline {
     margin-left: 20px;
-}
-
-li.doc-link.list-active a {
-    color: $mid-purple;
-    text-decoration: underline;
 }
 
 // 404 page styling


### PR DESCRIPTION
### Summary
Updated a few things:
* Used [`{% break %}`](https://shopify.github.io/liquid/tags/iteration/#break) to ensure the `show` class is only added once
* renamed `currentPage` to `currentEntry` to avoid confusion
* updated array [size](https://shopify.github.io/liquid/filters/size/) check
* updated the styling to be consistent with the rest of the nav, `ps-3` and (effectively) `pb-1`

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Follow up to #35 

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

Use the sub nav menu under Inso CLI -> CLI Command Reference

![image](https://user-images.githubusercontent.com/4312346/136872855-9592875d-1411-408b-9b53-7635e1676e21.png)

