### PR TITLE
[DOCU-1966] fix footer overlap on mobile

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,4 +1,4 @@
-<div class="footer mt-auto h-100 p-5 text-black bg-light" id="docs-footer">
+<div class="footer mt-auto h-100 p-5 text-black" id="docs-footer">
     <div class="container">
         <div class="row align-items-md-stretch">
             <div class="col-md-3">
@@ -30,6 +30,10 @@
                 </ul>
             </div>
         </div>
-        <small id="footer-copyright">© Kong Inc. 2021</small>  
-    </div>
+        <div class="row align-items-md-stretch">
+            <div class="col-md-12">
+                <small id="footer-copyright">© Kong Inc. 2021</small> 
+            </div>
+        </div>
+    </div>  
 </div>

--- a/docs/assets/css/styles.scss
+++ b/docs/assets/css/styles.scss
@@ -12,6 +12,10 @@ html {
 body {
     margin-bottom: 250px; /* Margin bottom by footer height */
     font-family: 'Inter', sans-serif;
+
+    @media (max-width: 767px) {
+        margin-bottom: 550px;
+    }
 }
 
 // logo and icon styling
@@ -275,7 +279,7 @@ p {
 
 @media (max-width: 767px) {
     #docs-footer {
-        max-height: 550px;
+        max-height: 560px;
     }
 }
 


### PR DESCRIPTION
### Summary

* Fix overlapping footer on mobile
* Fix bottom of footer so there's no gap on mobile

### Reason

Footer was overlapping content and making some content inaccessible on mobile. 
[INS-1104](https://linear.app/insomnia/issue/INS-1104/footer-overlaps-content-on-mobile)

### Testing

![Screen Shot 2021-10-28 at 10 45 43 AM](https://user-images.githubusercontent.com/22301405/139308315-02c91b88-340d-46ec-9ee4-bf77cd29e3cc.png)
