### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+FROM ruby:2.7-slim
+
+RUN apt-get -y update && apt-get install -y build-essential ruby-dev
+
+COPY docs /docs
+
+WORKDIR /docs
+
+RUN bundle install
+
+EXPOSE 4000 80
+CMD bundle exec jekyll serve --watch -H 0.0.0.0 -P 4000

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ Please refer to our [Contributing Guidelines](/CONTRIBUTING.md).
 4. Run `bundle install`.
 5. Run `bundle exec jekyll serve`.
 6. Browse to http://localhost:4000.
+
+### (Alternative) Run with docker
+
+1. Clone the repository.
+2. Install [docker](https://docs.docker.com/get-docker/).
+3. Run `make build`  or `docker build --tag insomnia-docs:latest .`.
+4. Run `make run` or `docker run -it --rm -p 4000:4000 insomnia-docs:latest`.
+5. Browse to http://localhost:4000.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Please refer to our [Contributing Guidelines](/CONTRIBUTING.md).
 5. Run `bundle exec jekyll serve`.
 6. Browse to http://localhost:4000.
 
-### (Alternative) Run with docker
+### Run with Docker
 
 1. Clone the repository.
-2. Install [docker](https://docs.docker.com/get-docker/).
+2. Install [Docker](https://docs.docker.com/get-docker/).
 3. Run `make build`  or `docker build --tag insomnia-docs:latest .`.
 4. Run `make run` or `docker run -it --rm -p 4000:4000 insomnia-docs:latest`.
 5. Browse to http://localhost:4000.

--- a/makefile
+++ b/makefile
@@ -1,0 +1,13 @@
+container_version := latest
+container_name := insomnia-docs
+
+build:
+	@clear
+	DOCKER_BUILDKIT=1 docker build --tag ${container_name}:${container_version} .
+
+run:
+	@docker run -it --rm -p 4000:4000 insomnia-docs:latest
+
+help:
+	@echo -e "build - build insomnia-docs container image."
+	@echo -e "run - Start insomnia-docs container image."


### PR DESCRIPTION
### Summary
- Provide a new Dockerfile for an insomnia-docs image.
- Provide a makefile to simplify docker build/run commands.

### Reason
- Provide a containerised way for folks to alternatively spin up insomnia-docs without needing to install ruby and bundler locally on their host machines.

### Testing
- Install [docker](https://docs.docker.com/get-docker/).
- Run `make build`  or `docker build --tag insomnia-docs:latest .`.
- Run `make run` or `docker run -it --rm -p 4000:4000 insomnia-docs:latest`.
- Browse to http://localhost:4000.
![Screenshot 2021-10-29 at 12 14 00](https://user-images.githubusercontent.com/11976836/139425414-4ff84a82-3c1e-4940-99ab-0ef6b730b6ac.png)
![Screenshot 2021-10-29 at 12 14 14](https://user-images.githubusercontent.com/11976836/139425420-8f0b6f27-3ae5-4d1b-8ac1-51198e841681.png)


