### PR TITLE
Typo in inso-generate-config.md

### DIFF
--- a/docs/inso-cli/cli-command-reference/inso-generate-config.md
+++ b/docs/inso-cli/cli-command-reference/inso-generate-config.md
@@ -39,7 +39,7 @@ Scope by a file on the filesystem
 
 `inso generate config spec.yaml`
 
-`inso generate config spec.yaml --workingDir another/dir<br>`
+`inso generate config spec.yaml --workingDir another/dir`
 
 Saving configuration output to file
 


### PR DESCRIPTION
Removes the `<br>` from the cli instructions