### PR TITLE
[DOCU-1916] update CLI docs according to README

### DIFF
--- a/docs/inso-cli/cli-command-reference/inso-export-spec.md
+++ b/docs/inso-cli/cli-command-reference/inso-export-spec.md
@@ -5,13 +5,15 @@ category: "CLI Command Reference"
 category-url: inso-cli
 ---
 
-This command will extract and export the raw OpenAPI specification from the data store. If the `--output` option is not specified, the specification will print to console.
+The `inso export spec` command extracts and exports the raw OpenAPI specification from the data store. If the `--output` option is not specified, the specification will print to console.
 
 ## Command
 
-`inso export spec [identifier]`
+```bash
+inso export spec [identifier]
+```
 
-`identifier` can be a specification name, or id. If this is not provided, you will be prompted to select a spec.
+[`identifier`](/inso-cli/introduction/#the-identifier-argument) can be a specification name, or id. If this is not provided, you will be prompted to select a spec.
 
 ## Options
 
@@ -22,18 +24,30 @@ Option  | Alias | Description
 
 ## Examples
 
-When running in the example [git-repo](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso/src/db/fixtures/git-repo) directory
+The following commands work when running in the example [git-repo](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso/src/db/fixtures/git-repo) directory.
 
-Not specifying any arguments will prompt:
+When you don't specify any arguments, you'll be prompted with:
 
-`inso export spec`
+```bash
+inso export spec
+```
 
-Scope by the specification name or id:
+Scope exporting by the specification name or ID:
 
-`inso export spec spc_46c5a4`
-`inso export spec "Sample Specification"`
+```bash
+inso export spec spc_46c5a4
+```
 
-Saving configuration output to file:
+```bash
+inso export spec "Sample Specification"
+```
 
-`inso export spec spc_46c5a4 --output output.yaml`
-`inso export spec spc_46c5a4 > output.yaml`
+Save an exported configuration output to a file:
+
+```bash
+inso export spec spc_46c5a4 --output output.yaml
+```
+
+```bash
+inso export spec spc_46c5a4 > output.yaml
+```

--- a/docs/inso-cli/cli-command-reference/inso-generate-config.md
+++ b/docs/inso-cli/cli-command-reference/inso-generate-config.md
@@ -5,48 +5,86 @@ category: "CLI Command Reference"
 category-url: inso-cli
 ---
 
-Similar to the Kong Kubernetes and Declarative config plugins for Insomnia, this command can generate configuration from an API specification, using [openapi-2-kong](https://github.com/Kong/insomnia/tree/develop/packages/openapi-2-kong).
+The `inso generate config` command generates a configuration from an API specification by using [openapi-2-kong](https://github.com/Kong/insomnia/tree/develop/packages/openapi-2-kong). It works similarly to the [Kong Kubernetes](https://insomnia.rest/plugins/insomnia-plugin-kong-kubernetes-config) and [Declarative config](https://insomnia.rest/plugins/insomnia-plugin-kong-declarative-config) plugins for Insomnia.
+
+For more in-depth information on working with other Kong products, see:
+
+* [Kong Declarative Config (for decK)](/insomnia/declarative-config/)
+* [Kong for Kubernetes](/insomnia/kong-for-kubernetes)
 
 ## Command
 
-`inso generate config [identifier]`
+```bash
+inso generate config [identifier]
+```
 
-`identifier` can be a specification name, or id, or a file path.
+[`identifier`](/inso-cli/introduction/#the-identifier-argument) is a specification name, or id, or a file path.
 
 ## Options
 
 {:.table .table-striped}
 Option | Alias | Description
 ----- | ----- | ------
-`--type <type>` |	-t	| type of configuration to generate, options are kubernetes and declarative (default: declarative )
+`--type <type>` |	-t	| type of configuration to generate, options are `kubernetes` and `declarative` (default: `declarative`)
 `--output <path>`	| -o | save the generated config to a file in the working directory
+`--tags <tags>` | | comma-separated list of tags to apply to each entity
 
 ## Examples
 
-When running in the example [git-repo](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso/src/db/fixtures/git-repo) directory
+The following commands work when running in the example [git-repo](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso/src/db/fixtures/git-repo) directory.
 
-Not specifying any arguments will prompt:
+When you don't specify any arguments, you'll be prompted with:
 
-`inso generate config`
+```bash
+inso generate config
+```
 
-Scope by the specification name or id
+Scope configuration generation by the Document name or ID:
 
-`inso generate config spc_46c5a4`
+```bash
+inso generate config spc_46c5a4
+```
 
-`inso generate config "Sample Specification"`
+```bash
+inso generate config "Sample Specification"
+```
 
-Scope by a file on the filesystem
+Scope configuration generation by a file on the filesystem:
 
-`inso generate config spec.yaml`
+```bash
+inso generate config spec.yaml
+```
 
-`inso generate config spec.yaml --workingDir another/dir<br>`
+```bash
+inso generate config spec.yaml --workingDir another/dir
+```
 
-Saving configuration output to file
+Save the configuration output to a file:
 
-`inso generate config spc_46c5a4 --output output.yaml`
+```bash
+inso generate config spc_46c5a4 --output output.yaml
+```
 
-`inso generate config spc_46c5a4 > output.yaml`
+```bash
+inso generate config spc_46c5a4 > output.yaml
+```
 
-Changing configuration output type
+Add tags to your generated configuration:
 
-`inso generate config "Sample Specification" --type kubernetes`
+```bash
+inso generate config spec.yaml --tags first
+```
+
+```bash
+inso generate config spec.yaml --tags "first,second"
+```
+
+Change the generated configuration output type to either `declarative` or `kubernetes`:
+
+```bash
+inso generate config spc_46c5a4 --type declarative
+```
+
+```bash
+inso generate config "Sample Specification" --type kubernetes
+```

--- a/docs/inso-cli/cli-command-reference/inso-lint-spec.md
+++ b/docs/inso-cli/cli-command-reference/inso-lint-spec.md
@@ -5,25 +5,34 @@ category: "CLI Command Reference"
 category-url: inso-cli
 ---
 
-This command adds the ability to lint and validate your OpenAPI specification. Lint results will be printed to the console, and Inso will exit with an appropriate exit code.
+The `inso lint spec` command lints and validates your OpenAPI specification. Lint results will be printed to the console, and Inso CLI will exit with an exit code.
 
 ## Command
 
-`inso lint spec [identifier]`
+```bash
+inso lint spec [identifier]
+```
 
 Lint the given specification, the user will be prompted to select a specification if one is not passed as an option.
 
-`identifier` can be a specification name, or id
+[`identifier`](/inso-cli/introduction/#the-identifier-argument) can be a specification name or id.
 
 ## Examples
 
-When running in the example [git-repo](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso/src/db/fixtures/git-repo) directory
+The following commands work when running in the example [git-repo](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso/src/db/fixtures/git-repo) directory.
 
-Not specifying any arguments will prompt
+When you don't specify any arguments, you'll be prompted with:
 
-`inso lint spec`
+```bash
+inso lint spec
+```
 
-Scope by the specification name or id
+Scope linting by the specification name or ID:
 
-`inso lint spec spc_46c5a4`
-`inso lint spec "Sample Specification"`
+```bash
+inso lint spec spc_46c5a4
+```
+
+```bash
+inso lint spec "Sample Specification"
+```

--- a/docs/inso-cli/cli-command-reference/inso-run-test.md
+++ b/docs/inso-cli/cli-command-reference/inso-run-test.md
@@ -5,17 +5,21 @@ category: "CLI Command Reference"
 category-url: inso-cli
 ---
 
-With the introduction of Unit Testing in Insomnia, this command adds the functionality to execute unit tests written inside Insomnia in your terminal or in a CI/CD environment. On execution, Inso CLI will report test results, and exit with an appropriate exit code.
+The `inso run test` command enables you to execute unit tests written inside Insomnia from your terminal or in a CI/CD environment. On execution, Inso CLI will report test results, and exit with an exit code.
 
 ## Command
 
-`inso run test [identifier]`
+```bash
+inso run test [identifier]
+```
 
 This prompts user for unit test suite and environment selection. After selection it will execute the selected unit test suite against the selected environment. You may choose to specify the suite and environment directly as well, see examples below.
 
-`identifier` can be the name or id of a workspace, document, or unit test suite.
+[`identifier`](/inso-cli/introduction/#the-identifier-argument) can be the name or id of a workspace, document, or unit test suite.
 
 ## Options
+
+The test runner is built on top of Mocha, thus many of the options behave as they would in Mocha. The options currently supported are:
 
 {:.table .table-striped}
 Option |  Alias |  Description
@@ -24,29 +28,44 @@ Option |  Alias |  Description
 `--testNamePattern <regex>` | -t | run tests that match the regex
 `--bail` | -b | abort ("bail") after the first test failure
 `--keepFile` | | do not delete the generated test file (useful for debugging)
+`--disableCertValidation` | | disable certificate validation for requests with SSL
 
 ## Examples
 
-When running in the example [git-repo](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso/src/db/fixtures/git-repo) directory
+The following commands work when running in the example [git-repo](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso/src/db/fixtures/git-repo) directory.
 
-Not specifying any arguments will prompt
+When you don't specify any arguments, you'll be prompted with:
 
-`inso run test`
+```bash
+inso run test
+```
 
-Scope by the document name or id
+Scope tests to the Document name or ID:
 
-`inso run test "Sample Specification" --env "OpenAPI env"`
+```bash
+inso run test "Sample Specification" --env "OpenAPI env"
+```
 
-`inso run test spc_46c5a4 --env env_env_ca046a`
+```bash
+inso run test spc_46c5a4 --env env_env_ca046a
+```
 
-Scope by the a test suite name or id
+Scope tests to a test suite name or ID:
 
-`inso run test "Math Suite" --env "OpenAPI env"`
+```bash
+inso run test "Math Suite" --env "OpenAPI env"
+```
 
-`inso run test uts-7f0f85 --env env_env_ca046a`
+```bash
+inso run test uts-7f0f85 --env env_env_ca046a
+```
 
-Scope by test name regex, and control test running and reporting
+Scope tests by test name regex, and control test running and reporting:
 
-`inso run test "Sample Specification" --testNamePattern Math --env env_env_ca046a`
+```bash
+inso run test "Sample Specification" --testNamePattern Math --env env_env_ca046a
+```
 
-`inso run test spc_46c5a4 --reporter progress --bail --keepFile`
+```bash
+inso run test spc_46c5a4 --reporter progress --bail --keepFile
+```

--- a/docs/inso-cli/cli-command-reference/inso-script.md
+++ b/docs/inso-cli/cli-command-reference/inso-script.md
@@ -5,17 +5,19 @@ category: "CLI Command Reference"
 category-url: inso-cli
 ---
 
-The [Inso config file](/inso-cli/configuration/) supports scripts, akin to NPM scripts defined in a package.json file. These scripts can be executed by running `inso script <name>`, or `inso <name>`. Any options passed to this command, will be forwarded to the script being executed.
+The [Inso config file](/inso-cli/configuration/) supports scripts, similar to NPM scripts defined in a `package.json` file. These scripts can be executed by running `inso script <name>`, or `inso <name>`. Any options passed to this command will be forwarded to the script being executed.
 
 ## Command
 
-`inso script <name>`
+```bash
+inso script <name>
+```
 
-`name` is required, and must be a script defined in the loaded config file.
+`name` is required, and must be a script defined in the loaded configuration file.
 
 ## Examples
 
-When running in the example [git-repo](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso/src/db/fixtures/git-repo) directory, with the following inso config file.
+The following commands work when running in the example [git-repo](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso/src/db/fixtures/git-repo) directory with the sample yaml file.
 
 ```yaml
 # .insorc.yaml
@@ -27,19 +29,24 @@ scripts:
   gen-conf:k8s: gen-conf --type kubernetes<br>
 ```
 
-Run commands with or without the script prefix.
+Run commands with or without the `script` prefix:
 
-`inso script gen-conf`
-`inso gen-conf`
+```bash
+inso script gen-conf
+```
 
-If a conflict exists with another command (eg. lint), you must prefix with `script`.
+```bash
+inso gen-conf
+```
+
+If a conflict exists with another command (such as `lint`), you must prefix the command with `script`.
 
 ```bash
 inso script lint
 inso lint          # will not work
 ```
 
-Any options passed during script execution will be forwarded to the script.
+Any options passed during script execution will be forwarded to the script:
 
 ```bash
 inso gen-conf                       # generates declarative config (default)

--- a/docs/inso-cli/configuration.md
+++ b/docs/inso-cli/configuration.md
@@ -7,7 +7,7 @@ category-url: inso-cli
 
 Inso CLI can be configured with a configuration file, allowing you to specify options and scripts. For example, when running in a CI environment, you may choose to specify the steps as scripts in a config file, so that the same commands can be run both locally and in CI.
 
-Inso CLI uses cosmiconfig for config file management, meaning any of the following items found in the working tree are automatically used:
+Inso CLI uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for configuration file management, meaning any of the following items found in the working tree are automatically used:
 
 * `inso` property in `package.json`
 * `.insorc` file in JSON or YAML format
@@ -19,15 +19,19 @@ Alternatively, you can use the `--config <file>` global option to specify an exa
 
 ## Options
 
-Options from the config file are combined with option defaults and any explicit overrides specified in script or command invocations. This combination is in priority order: command options > config file options > default options.
+Options from the config file are combined with option defaults and any explicit overrides specified in script or command invocations. This combination is in the following priority order: 
+
+1. command options
+2. config file options
+3. default options
 
 Any options specified in this file will apply to all scripts and manual commands. You can override these options by specifying them explicitly, when invoking a script or command.
 
-Only global options can be set in the config file.
+Only [global options](/inso-cli/introduction/#global-options) can be set in the config file.
 
 ## Scripts
 
-Scripts can have any name, and can be nested. Scripts must be prefixed with inso (see example below). Each command behaves the same way, as described in the sections above.
+Scripts can have any name, and can be nested. Scripts must be prefixed with `inso`. Each command behaves the same way, as described in [Options](#options).
 
 ## Example
 

--- a/docs/inso-cli/continuous-integration.md
+++ b/docs/inso-cli/continuous-integration.md
@@ -7,7 +7,16 @@ category-url: inso-cli
 
 Inso CLI has been designed to run in a CI environment, disabling prompts, and providing exit codes to pass or fail the CI workflow.
 
-An example workflow run in Github Actions is as follows. This example will checkout > install NodeJS > install inso > run linting > run unit tests > generate configuration. If any of these steps fail, the GH workflow will as well.
+An example workflow run in Github Actions is as follows and performs the following:
+
+1. Checkout
+2. Install NodeJS
+3. Install Inso CLI
+4. Run linting
+5. Run unit tests
+6. Generate a declaractive configuration file
+
+If any of these steps fail, the GitHub workflow will as well.
 
 ```yaml
 # .github/workflows/test.yml
@@ -31,5 +40,4 @@ jobs:
         run: inso run test "Designer Demo" --env UnitTest --ci
       - name: Generate declarative config
         run: inso generate config "Designer Demo" --type declarative --ci
-<br>
 ```

--- a/docs/inso-cli/install.md
+++ b/docs/inso-cli/install.md
@@ -5,18 +5,7 @@ category: "Inso CLI"
 category-url: inso-cli
 ---
 
-## Install single executable
-
-Inso CLI can be downloaded and run as a single executable on MacOS, Windows or Linux. Download the release artifacts from [GitHub Releases](https://github.com/Kong/insomnia/releases/tag/lib%402.4.0).
-
-### Windows
-
-On Windows, you will need to extract the executable using [7zip](https://www.7-zip.org/), or via the command prompt:
-
-```sh
-tar -xf inso-windows-2.4.0.zip
-./inso --version
-```
+Install Inso CLI via NPM or using single executable.
 
 ## Install via NPM
 
@@ -40,3 +29,16 @@ Once you have installed Node.js, you can install Inso CLI globally on your syste
 Test that Inso CLI is installed by running:
 
 `inso --version`
+
+## Install single executable
+
+Inso CLI can be downloaded and run as a single executable on MacOS, Windows or Linux. Download the release artifacts from [GitHub Releases](https://github.com/Kong/insomnia/releases/tag/lib%402.4.0).
+
+### Windows
+
+On Windows, you will need to extract the executable using [7zip](https://www.7-zip.org/), or via the command prompt:
+
+```sh
+tar -xf inso-windows-2.4.0.zip
+./inso --version
+```

--- a/docs/inso-cli/install.md
+++ b/docs/inso-cli/install.md
@@ -16,7 +16,9 @@ Install Inso CLI via NPM or using single executable.
 
 Before you start, install [Node.js](https://nodejs.org/en/download). If you're unsure if you have Node.js installed already (or which version), you can run the following command in your terminal:
 
-`node --version`
+```bash
+node --version
+```
 
 If a version number prints, then you have Node.js installed. If the version is not 12, set up [nvm](https://github.com/nvm-sh/nvm) on your local machine to work with Node.js 12.
 
@@ -24,15 +26,19 @@ If a version number prints, then you have Node.js installed. If the version is n
 
 Once you have installed Node.js, you can install Inso CLI globally on your system by running the following command in your terminal:
 
-`npm install -g insomnia-inso`
+```bash
+npm install --global insomnia-inso
+```
 
 Test that Inso CLI is installed by running:
 
-`inso --version`
+```bash
+inso --version
+```
 
 ## Install single executable
 
-Inso CLI can be downloaded and run as a single executable on MacOS, Windows or Linux. Download the release artifacts from [GitHub Releases](https://github.com/Kong/insomnia/releases/tag/lib%402.4.0).
+Inso CLI can be downloaded and run as a single executable on MacOS, Windows, and Linux. Download the release artifacts from [GitHub Releases](https://github.com/Kong/insomnia/releases/tag/lib%402.4.0).
 
 ### Windows
 

--- a/docs/inso-cli/introduction.md
+++ b/docs/inso-cli/introduction.md
@@ -47,8 +47,25 @@ Inso CLI can work with three data sources.
 * Git data directory if [Git Sync](/insomnia/git-sync) is set up and no `--src` is set. For example, when running in CI, InsoCLI will find the `.insomnia` directory at the root of the repository automatically, but you can override the location using `--workingDir`.
 * Insomnia export file. Search for an export file using `--src`.
 
+{:.alert .alert-primary}
+**Note**: The `.insomnia` directory is generated automatically in your git repository when using [Git Sync](/insomnia/git-sync).
+
 ### Data Search Flow
 
 Inso CLI will first try to find a `.insomnia` directory in its working directory. This directory is generated in a git repository when using [Git Sync](/insomnia/git-sync). When Inso is used in a CI environment, it will automatically run against the `.insomnia` directory at the root of the repository, unless you specify a `--workingDir` or `--src` option.
 
 If Inso CLI cannot find the `.insomnia` directory, it will try to run against the Insomnia app data directory. You can override both the working directory, and the app data directory, using the `--workingDir` and `--src` global options.
+
+## The identifier Argument
+
+Insomnia database ids are quite long, for example: `wrk_012d4860c7da418a85ffea7406e1292a`. When specifying an identifier for Inso CLI, similar to Git hashes, you may choose to concatenate and use the first `x` characters (for example, `wrk_012d486`), which is likely to be unique. If in the rare chance the short id is not unique against the data, Inso CLI will indicate that.
+
+Additionally, if the `identifier` argument is omitted from the command, Inso CLI will search in the database for the information it needs, and prompt the user. Prompts can be disabled with the `--ci global` option.
+
+## Git Bash
+
+Git Bash on Windows is not interactive, so prompts from Inso CLI will not work as expected. You can specify identifiers for each command explicitly, or run Inso CLI using a tool like [winpty](https://github.com/rprichard/winpty). The following is an example Inso CLI command using winpty:
+
+```bash
+winpty inso.cmd generate config
+```


### PR DESCRIPTION
### Summary

* Audit [Inso CLI README](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso) in comparison with the Inso CLI docs on docs.insomnia.net
* Add missing content and refine existing content

**Scope of this PR**: Check for missing content, clarify language, and updating formatting. 

Future steps are adding a link from the [Inso CLI README](https://github.com/Kong/insomnia/tree/develop/packages/insomnia-inso) to our documentation and removing most content from the README so we don't have two sources of docs to maintain. 

### Reason

* We currently have to maintain Inso CLI documentation in two places
* The documentation was not fully up-to-date and had largely not been updated since copy-🍝 from HelpScout
