### PR TITLE
Fix cmd to enable key-repeating in Vim mode on Mac

### DIFF
--- a/docs/insomnia/key-maps.md
+++ b/docs/insomnia/key-maps.md
@@ -18,4 +18,4 @@ By default, press-and-hold on macOS shows special characters.
 
 This is not particularly useful when using the Vim key map, because navigation is restricted to one move at a time. In order to enable key-repeating, execute the following in your terminal and restart Insomnia:
 
-`defaults write com.insomnia.app ApplePressAndHoldEnabled -bool false<br>`
+`defaults write com.insomnia.app ApplePressAndHoldEnabled -bool false`


### PR DESCRIPTION
### Summary
I believe I found a small typo in the documentation concerning how to enable key-repeating for Vim mode on Mac.

The original command on the page read:
`defaults write com.insomnia.app ApplePressAndHoldEnabled -bool false<br>` 

and I couldn't run it from zsh. I got this output: 
`zsh: parse error near \n`

when I got rid of the `<br>`, it worked. I restarted Insomnia and had the key-repeating I wanted, so I regarded this as a typo, probably due to page layout needs. Just in case it's for the layout, I added a newline below the command, outside the backticks.
### Reason
Simple enough. I was a little confused by this typo and since I was able to fix it easily, I figured I could improve the docs for future users.

### Testing
Very easy to test (must be on MacOS; I also use zsh and iTerm2 but I doubt that matters). 
- [ ] Go to preferences and change the key map to Vim
- [ ] Run this command: `defaults write com.insomnia.app ApplePressAndHoldEnabled -bool false<br>` (should fail with parse error)
- [ ] Now remove the `<br>` and note the success.
- [ ] Restart Insomnia and attempt to scroll up and down a request page by holding K or J respectively.
<img width="637" alt="Screen Shot 2021-10-29 at 11 28 43 PM" src="https://user-images.githubusercontent.com/72025944/139519031-d02f1a89-fcb1-4658-9086-deb58c41bfda.png">
screenshot of my terminal, showing both the unsuccessful command with the typo and the successful command without it.
