### PR TITLE
Expand plugin request body reference and add examples

### DIFF
--- a/docs/insomnia/context-object-reference.md
+++ b/docs/insomnia/context-object-reference.md
@@ -77,6 +77,24 @@ module.exports.requestHooks = [
 ];
 ```
 
+### Example: Alter request body
+
+```ts
+// Replace "FOO" with "BAR" within a request body before sending
+const regexp = new RegExp(/FOO/, 'g');
+
+module.exports.requestHooks = [
+  context => {
+    const body = context.request.getBody();
+    context.request.setBody({
+      ...body,
+      text: body.text.replace(regexp, 'BAR'),
+    });
+  }
+];
+
+```
+
 ## context.response
 
 The response context contains helpers to interact with an Insomnia response.

--- a/docs/insomnia/context-object-reference.md
+++ b/docs/insomnia/context-object-reference.md
@@ -31,8 +31,8 @@ interface RequestContext {
     hasParameter(name: string): boolean;
     addParameter(name: string, value: string): void;
     removeParameter(name: string): void;
-    getBody(): Object;
-    setBody(body: Object): void;
+    getBody(): RequestBody;
+    setBody(body: RequestBody): void;
     getEnvironmentVariable(name: string): any;
     getEnvironment(): Object;
     setAuthenticationParameter(name: string, value: string): void;
@@ -44,6 +44,24 @@ interface RequestContext {
     settingDisableRenderRequestBody(enabled: boolean): void;
     settingFollowRedirects(enabled: boolean): void;
 };
+
+interface RequestBody {
+  mimeType?: string;
+  text?: string;
+  fileName?: string;
+  params?: RequestBodyParameter[];
+}
+
+interface RequestBodyParameter {
+  name: string;
+  value: string;
+  description?: string;
+  disabled?: boolean;
+  multiline?: string;
+  id?: string;
+  fileName?: string;
+  type?: string;
+}
 ```
 
 ### Example: Set Content-Type header on every POST request

--- a/docs/insomnia/context-object-reference.md
+++ b/docs/insomnia/context-object-reference.md
@@ -92,8 +92,20 @@ module.exports.requestHooks = [
     });
   }
 ];
-
 ```
+
+### Example: Override request body
+
+```ts
+module.exports.requestHooks = [
+  context => {
+    context.request.setBody({
+      mimeType: 'application/json',
+      text: JSON.stringify({ foo: 'bar' }),
+    });
+  }
+];
+
 
 ## context.response
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

This PR expands the object type expected by `context.request.setBody()` and adds two examples to demonstrate how to alter or override the request body.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Follow up to https://github.com/Kong/insomnia/issues/4193.
