### PR TITLE
[DOCU-1858] create collaboration section

### DIFF
--- a/docs/_data/main-nav.yaml
+++ b/docs/_data/main-nav.yaml
@@ -12,12 +12,6 @@ toc:
         url: /insomnia/import-export-data
       - title: Environment Variables
         url: /insomnia/environment-variables
-      - title: Projects
-        url: /insomnia/projects
-      - title: Team Collaboration
-        url: /insomnia/team-collaboration
-      - title: Version Control Sync
-        url: /insomnia/version-control-sync
       - title: HTTP(S) Proxy
         url: /insomnia/http-proxy
       - title: Insomnia Configuration File
@@ -37,13 +31,22 @@ toc:
         url: /insomnia/post-csv-data
       - title: SOAP Requests
         url: /insomnia/soap-requests
+  - title: Collaboration
+    collapse-id: collaboration
+    items:
+      - title: Teams
+        url: /insomnia/teams
+      - title: Projects
+        url: /insomnia/projects
+      - title: Sync with Git
+        url: /insomnia/git-sync
+      - title: Version Control Sync
+        url: /insomnia/version-control-sync
   - title: API Design
     collapse-id: design
     items:
       - title: Design Documents
         url: /insomnia/design-documents
-      - title: Sync with Git
-        url: /insomnia/git-sync
       - title: Linting
         url: /insomnia/linting
       - title: GraphQL for OpenAPI

--- a/docs/insomnia/projects.md
+++ b/docs/insomnia/projects.md
@@ -18,7 +18,7 @@ _Projects are available via the main Insomnia dropdown. Here, you will find the 
 
 ### Default Project
 
-This is a persistent Project that always exists for all users by default. It cannot be renamed or deleted. It appears next to the home icon in the Projects dropdown menu.
+The "Insomnia" Project exists for all users by default. It cannot be renamed or deleted. It appears next to the home icon in the Projects dropdown menu.
 
 ### Local Project
 

--- a/docs/insomnia/teams.md
+++ b/docs/insomnia/teams.md
@@ -1,8 +1,8 @@
 ---
 layout: article-detail
-title: Team Collaboration
-category: "Get Started"
-category-url: get-started
+title: Teams
+category: "Collaboration"
+category-url: collaboration
 ---
 
 {:.alert .alert-primary}
@@ -12,7 +12,7 @@ Teams gives you the ability to collaborate on Insomnia Request Collections with 
 
 ## Create a Team
 
-A team can be created in the [web dashboard](https://app.insomnia.rest/app/signup/). 
+A team can be created in the [web dashboard](https://app.insomnia.rest/app/signup/).
 
 ## Share Request Collections With a Team
 

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -99,7 +99,7 @@
     { "source": "/article/184-(.*)", "destination": "/insomnia/run-in-insomnia-button", "permanent": false },
     { "source": "/article/190-(.*)", "destination": "/insomnia/soap-requests", "permanent": false },
     { "source": "/article/181-(.*)", "destination": "/insomnia/ssl-validation", "permanent": false },
-    { "source": "/article/163-(.*)", "destination": "/insomnia/team-collaboration", "permanent": false },
+    { "source": "/article/163-(.*)", "destination": "/insomnia/teams", "permanent": false },
     { "source": "/article/211-(.*)", "destination": "/insomnia/projects", "permanent": false },
     { "source": "/article/195-(.*)", "destination": "/insomnia/install#uninstall-on-windows", "permanent": false },
     { "source": "/article/194-(.*)", "destination": "/insomnia/unit-testing", "permanent": false },
@@ -121,6 +121,8 @@
 
     { "source": "/article/(.*)", "destination": "/", "permanent": false },
     { "source": "/category/(.*)", "destination": "/", "permanent": false },
-    { "source": "/collection/(.*)", "destination": "/", "permanent": false }
+    { "source": "/collection/(.*)", "destination": "/", "permanent": false },
+
+    { "source": "/insomnia/team-collaboration", "destination": "/insomnia/teams", "permanent": false}
   ]
 }


### PR DESCRIPTION
### Summary

Create Collaboration section to get users to collaboration content quicker.

### Reason

More intuitive structure. 

@DMarby I added a redirect from `team-collaboration` to `teams` because I renamed the file. Can you please check that I did it correctly?