### PR TITLE
chore(doc): add homebrew instructions for MacOS

### DIFF
--- a/docs/inso-cli/install.md
+++ b/docs/inso-cli/install.md
@@ -48,3 +48,11 @@ On Windows, you will need to extract the executable using [7zip](https://www.7-z
 tar -xf inso-windows-2.4.0.zip
 ./inso --version
 ```
+
+### MacOS
+
+Inso CLI can also be installed via Homebrew on MacOS:
+
+```bash
+brew install inso
+```


### PR DESCRIPTION
### Summary
Adds instructions for installing `inso` via Homebrew now that https://github.com/Homebrew/homebrew-cask/pull/113376 is merged.

### Reason
Making `inso` easier to install and access!

### Testing
N/A
