### PR TITLE
Update context-object-reference.md

### DIFF
--- a/docs/insomnia/context-object-reference.md
+++ b/docs/insomnia/context-object-reference.md
@@ -105,7 +105,7 @@ module.exports.requestHooks = [
     });
   }
 ];
-
+```
 
 ## context.response
 
@@ -125,6 +125,7 @@ interface ResponseContext {
     getHeaders(): Array<{ name: string, value: string }> | undefined;
     hasHeader(name: string): boolean,
 }
+
 ```
 
 ### Example: Save response to file


### PR DESCRIPTION
### Summary
Someone deleted the closing ``` tag in one of the examples. 

### Reason
The text on that sectoin of the page was all screwed up.

### Testing
Looks OK now. 👍