### PR TITLE
Update config generator plugin API and document unlisted option

### DIFF
--- a/docs/insomnia/hooks-and-actions.md
+++ b/docs/insomnia/hooks-and-actions.md
@@ -173,11 +173,14 @@ Actions can be added to a Dashboard card context menu for a Document. This actio
 ```ts
 interface DocumentAction {
     label: string,
-    action: (context: Context, spec: 
+    action: (
+      context: Context,
+      spec: {
         contents: Record<string, any>;
         rawContents: string;
         format: string;
         formatVersion: string;
+      }
     ): void | Promise<void>;
     hideAfterClick?: boolean;
 };
@@ -193,7 +196,16 @@ Config generators show in the Document settings dropdown, and can be used to gen
 ```ts
 interface ConfigGenerator {
     label: string;
-    generate: (info: SpecInfo) => Promise<{ document?: string; error?: string; }>;
+    docsLink?: string;
+    generate: (spec: {
+      contents: Record<string, any>;
+      rawContents: string;
+      format: string;
+      formatVersion: string;
+    }) => Promise<{
+      document?: string;
+      error?: string;
+    }>;
 };
 
 // Config generators are exported as an array of objects

--- a/docs/insomnia/introduction-to-plugins.md
+++ b/docs/insomnia/introduction-to-plugins.md
@@ -105,7 +105,9 @@ The following is an example minimal `package.json`. The `package.json` must cont
     "publisher": {
       "name": "YOUR NAME HERE", // Plugin publisher name, displayed on plugin hub
       "icon": "https://...",    // Plugin publisher avatar or icon, absolute url
-    }
+    },
+
+    "unlisted": false // Set to true if this plugin should not be available on the Plugin Hub
   },
   
   // External dependencies are also supported


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Follow-ups to
* https://github.com/Kong/insomnia-website/pull/16#pullrequestreview-805871893 (document the `unlisted` option) 
* https://github.com/Kong/insomnia/pull/4204 (add `docsLink` to config generator plugins).

This PR also does some cleanup to resolve invalid TS syntax.
