### PR TITLE
[DOCU-2029] Add --format option for inso generate config

### DIFF
--- a/docs/inso-cli/cli-command-reference/inso-generate-config.md
+++ b/docs/inso-cli/cli-command-reference/inso-generate-config.md
@@ -25,8 +25,9 @@ inso generate config [identifier]
 {:.table .table-striped}
 Option | Alias | Description
 ----- | ----- | ------
-`--type <type>` |	-t	| type of configuration to generate, options are `kubernetes` and `declarative` (default: `declarative`)
-`--output <path>`	| -o | save the generated config to a file in the working directory
+`--type <type>` |	`-t`	| type of configuration to generate, options are `kubernetes` and `declarative` (default: `declarative`)
+`--output <path>`	| `-o` | save the generated config to a file in the working directory
+`--format` | `-f` | the output format, either `yaml` or `json`. This option only applies to type `declarative`, and will be ignored for type `kubernetes` (default: `yaml`)
 `--tags <tags>` | | comma-separated list of tags to apply to each entity
 
 ## Examples
@@ -67,6 +68,12 @@ inso generate config spc_46c5a4 --output output.yaml
 
 ```bash
 inso generate config spc_46c5a4 > output.yaml
+```
+
+Save the configuration output to a file with json output:
+
+```bash
+inso generate config spc_46c5a4 --output output.json --format json
 ```
 
 Add tags to your generated configuration:


### PR DESCRIPTION
### Summary

* Add `--format` to Options table on inso generate config page
* Add a note in `--output` in Options table about using `--format`
* Add example of how to modify to json format

### Reason

[INS-1184](https://linear.app/insomnia/issue/INS-1184/document-the-output-option-with-inso-generate-config)
Duplicate for JIRA tracking: [DOCU-2029](https://konghq.atlassian.net/browse/DOCU-2029)

### Testing

Link TBA.
