### PR TITLE
[DOCU-2030] Add accessible tabs to Inso CLI install

### DIFF
--- a/docs/assets/css/styles.scss
+++ b/docs/assets/css/styles.scss
@@ -167,7 +167,6 @@ figure.highlight>pre>code {
 .nav-link {
     color: white !important;
     display: inline;
-    padding-right: 0px !important;
 
     &:hover {
         text-decoration: underline;
@@ -343,4 +342,15 @@ p {
 
 .z-sidebar {
     z-index: 0;
+}
+
+// sideways tabs
+.side-tabs {
+    color: black !important;
+}
+
+.tab-content {
+    padding-top: 10px;
+    padding-right: 5px;
+    margin-bottom: 30px;
 }

--- a/docs/inso-cli/cli-command-reference/inso-generate-config.md
+++ b/docs/inso-cli/cli-command-reference/inso-generate-config.md
@@ -25,8 +25,9 @@ inso generate config [identifier]
 {:.table .table-striped}
 Option | Alias | Description
 ----- | ----- | ------
-`--type <type>` |	-t	| type of configuration to generate, options are `kubernetes` and `declarative` (default: `declarative`)
-`--output <path>`	| -o | save the generated config to a file in the working directory
+`--type <type>` |	`-t`	| type of configuration to generate, options are `kubernetes` and `declarative` (default: `declarative`)
+`--output <path>`	| `-o` | save the generated config to a file in the working directory. The default output is `yaml`. Change the output type to `json` for type `declarative` with the `--format` option.
+`--format` | `-f` | output format, either `yaml` or `json`. This option only applies to type `declarative`, and will be ignored for type `kubernetes` (default: `yaml`)
 `--tags <tags>` | | comma-separated list of tags to apply to each entity
 
 ## Examples
@@ -67,6 +68,12 @@ inso generate config spc_46c5a4 --output output.yaml
 
 ```bash
 inso generate config spc_46c5a4 > output.yaml
+```
+
+Save the configuration output to a file with json output:
+
+```bash
+inso generate config spc_46c5a4 --output output.json --format json
 ```
 
 Add tags to your generated configuration:

--- a/docs/inso-cli/install.md
+++ b/docs/inso-cli/install.md
@@ -5,7 +5,38 @@ category: "Inso CLI"
 category-url: inso-cli
 ---
 
-Install Inso CLI via NPM or using single executable.
+Install Inso CLI using our single executable commands for your operating system, or by using NPM.
+
+## Install Single Executable
+
+Inso CLI can be downloaded and run as a single executable on MacOS, Windows, and Linux. Download the release artifacts from [GitHub Releases](https://github.com/Kong/insomnia/releases/tag/lib%402.4.0).
+
+To use our single executable options, select your operating system.
+
+<nav>
+  <div class="nav nav-tabs" id="nav-tab" role="tablist">
+    <button class="nav-link active side-tabs" id="nav-home-tab" data-bs-toggle="tab" data-bs-target="#nav-home" type="button" role="tab" aria-controls="nav-home" aria-selected="true">MacOS</button>
+    <button class="nav-link side-tabs" id="nav-profile-tab" data-bs-toggle="tab" data-bs-target="#nav-profile" type="button" role="tab" aria-controls="nav-profile" aria-selected="false">Windows</button>
+    <button class="nav-link side-tabs" id="nav-contact-tab" data-bs-toggle="tab" data-bs-target="#nav-contact" type="button" role="tab" aria-controls="nav-contact" aria-selected="false">Linux</button>
+  </div>
+</nav>
+<div class="tab-content" id="nav-tabContent">
+  <div class="tab-pane fade show active" id="nav-home" role="tabpanel" aria-labelledby="nav-home-tab">
+  On MacOS, Inso CLI can also be installed via Homebrew:
+<br/><br/>
+<pre class="highlight"><code>brew install inso</code></pre>
+  </div>
+  <div class="tab-pane fade" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">
+  On Windows, extract the executable using <a href="https://www.7-zip.org/">7zip</a>, or via the command prompt:
+  <br/><br/>
+<pre class="highlight"><code>tar -xf inso-windows-2.4.0.zip
+./inso --version</code></pre>
+  </div>
+  <div class="tab-pane fade" id="nav-contact" role="tabpanel" aria-labelledby="nav-contact-tab">On Linux, download the Linux tar file from <a href="https://github.com/Kong/insomnia/releases/tag/lib%402.4.0">GitHub</a>. Extract the file by using the following command where <code>{name}</code> is the tar file name:
+  <br/><br/>
+  <pre class="highlight"><code>tar -xf {name}.tar.xz</code></pre>
+  </div>
+</div>
 
 ## Install via NPM
 
@@ -34,25 +65,4 @@ Test that Inso CLI is installed by running:
 
 ```bash
 inso --version
-```
-
-## Install single executable
-
-Inso CLI can be downloaded and run as a single executable on MacOS, Windows, and Linux. Download the release artifacts from [GitHub Releases](https://github.com/Kong/insomnia/releases/tag/lib%402.4.0).
-
-### Windows
-
-On Windows, you will need to extract the executable using [7zip](https://www.7-zip.org/), or via the command prompt:
-
-```sh
-tar -xf inso-windows-2.4.0.zip
-./inso --version
-```
-
-### MacOS
-
-Inso CLI can also be installed via Homebrew on MacOS:
-
-```bash
-brew install inso
 ```

--- a/docs/inso-cli/install.md
+++ b/docs/inso-cli/install.md
@@ -22,19 +22,37 @@ To use our single executable options, select your operating system.
 </nav>
 <div class="tab-content" id="nav-tabContent">
   <div class="tab-pane fade show active" id="nav-home" role="tabpanel" aria-labelledby="nav-home-tab">
-  On MacOS, Inso CLI can also be installed via Homebrew:
+  On MacOS, download the MacOS zip or pkg from <a href="https://github.com/Kong/insomnia/releases/tag/lib%402.4.0">GitHub</a> or use Homebrew. If you use the pkg option, click through the prompt window as you normally would when downloading an app from the internet.
+<br/><br/>
+<h4>Extract the Zip File</h4>
+If you download the zip file, extract it from Finder or with the following command:
+<br/><br/>
+<pre class="highlight"><code>tar -xf inso-macos-2.4.0.zip</code></pre>
+  Check that Inso CLI was properly installed with the following command:
+<br/><br/>
+<pre class="highlight"><code>./inso --version</code></pre>
+<h4>Use Homebrew</h4>
+Install Inso CLI using Homebrew with the following command:
 <br/><br/>
 <pre class="highlight"><code>brew install inso</code></pre>
+Check that Inso CLI was properly installed with the following command:
+<br/><br/>
+<pre class="highlight"><code>inso --version</code></pre>
   </div>
   <div class="tab-pane fade" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">
-  On Windows, extract the executable using <a href="https://www.7-zip.org/">7zip</a>, or via the command prompt:
+  On Windows, download the Windows zip file from <a href="https://github.com/Kong/insomnia/releases/tag/lib%402.4.0">GitHub</a>. Then, extract the executable using <a href="https://www.7-zip.org/">7zip</a>, or via the following command:
   <br/><br/>
-<pre class="highlight"><code>tar -xf inso-windows-2.4.0.zip
-./inso --version</code></pre>
+<pre class="highlight"><code>tar -xf inso-windows-2.4.0.zip</code></pre>
+Check that Inso CLI was properly installed with the following command:
+<br/><br/>
+<pre class="highlight"><code>./inso --version</code></pre>
   </div>
-  <div class="tab-pane fade" id="nav-contact" role="tabpanel" aria-labelledby="nav-contact-tab">On Linux, download the Linux tar file from <a href="https://github.com/Kong/insomnia/releases/tag/lib%402.4.0">GitHub</a>. Extract the file by using the following command where <code>{name}</code> is the tar file name:
+  <div class="tab-pane fade" id="nav-contact" role="tabpanel" aria-labelledby="nav-contact-tab">On Linux, download the Linux tar file from <a href="https://github.com/Kong/insomnia/releases/tag/lib%402.4.0">GitHub</a>. Extract the file by using the following command:
   <br/><br/>
-  <pre class="highlight"><code>tar -xf {name}.tar.xz</code></pre>
+  <pre class="highlight"><code>tar -xf inso-linux-2.4.0.tar.xz</code></pre>
+  Check that Inso CLI was properly installed with the following command:
+<br/><br/>
+<pre class="highlight"><code>./inso --version</code></pre>
   </div>
 </div>
 


### PR DESCRIPTION
### Summary

* Add accessible tabs to Inso CLI install. 
* Front-load the page with single executable options. 

### Reason

Closes [INS-1188](https://linear.app/insomnia/issue/INS-1188/docs-update-inso-cli-page-to-front-load-platform-specific-instructions)
Closes [DOCU-2030](https://konghq.atlassian.net/browse/DOCU-2030)

### Testing

https://insomnia-docs-git-docu-2030-teaminsomnia.vercel.app/inso-cli/install
