### PR TITLE
[DOCU-2107] add Export and Import Data sections

### DIFF
--- a/docs/insomnia/import-export-data.md
+++ b/docs/insomnia/import-export-data.md
@@ -7,16 +7,13 @@ category-url: get-started
 
 Insomnia supports importing and exporting. Currently, the supported import formats are Insomnia, Postman v2, HAR, OpenAPI, Swagger, WSDL, and cURL.
 
-To import or export data, go to **Preferences**, then the **Data** tab.
-
-![The Data tab in Preferences allows you to import or export data via dropdown options.](/assets/images/import-export-data.png)
-_The Data tab in Preferences allows you to import or export data via dropdown options._
-
 ## Export Data
 
 Export a Document, Collection, or a single request.
 
-In **Preferences** and under the **Data** tab, select an option from the **Export Data** dropdown menu. If you're inside a Document or Collection, you'll have the option to export that specific Document or Collection.
+From the Document or Collection name dropdown menu, select **Import/Export**. Select an option from the **Export Data** dropdown menu.
+
+Alternatively, in **Preferences** and under the **Data** tab, select an option from the **Export Data** dropdown menu. If you're inside a Document or Collection, you'll have the option to export that specific Document or Collection.
 
 If you've selected to export a Document or Collection, choose to export the whole set or individual requests.
 
@@ -24,7 +21,9 @@ If you've selected to export a Document or Collection, choose to export the whol
 
 Import data from a file, URL, or Clipboard.
 
-In **Preferences** and under the **Data** tab, select an option from the **Import Data** dropdown menu.
+From the Document or Collection name dropdown menu, select **Import/Export**. Select an option from the **Import Data** dropdown menu.
+
+Alternatively, in **Preferences** and under the **Data** tab, select an option from the **Import Data** dropdown menu.
 
 ## Export Special Resources and Resource Types
 

--- a/docs/insomnia/import-export-data.md
+++ b/docs/insomnia/import-export-data.md
@@ -7,14 +7,28 @@ category-url: get-started
 
 Insomnia supports importing and exporting. Currently, the supported import formats are Insomnia, Postman v2, HAR, OpenAPI, Swagger, WSDL, and cURL.
 
-To import or export data, go to **Preferences**, then the **Data** tab. 
+To import or export data, go to **Preferences**, then the **Data** tab.
 
 ![The Data tab in Preferences allows you to import or export data via dropdown options.](/assets/images/import-export-data.png)
 _The Data tab in Preferences allows you to import or export data via dropdown options._
 
+## Export Data
+
+Export a Document, Collection, or a single request.
+
+In **Preferences** and under the **Data** tab, select an option from the **Export Data** dropdown menu. If you're inside a Document or Collection, you'll have the option to export that specific Document or Collection.
+
+If you've selected to export a Document or Collection, choose to export the whole set or individual requests.
+
+## Import Data
+
+Import data from a file, URL, or Clipboard.
+
+In **Preferences** and under the **Data** tab, select an option from the **Import Data** dropdown menu.
+
 ## Export Special Resources and Resource Types
 
-The following outlines special resource IDs, used to map to data, and resource types, used to outline what's included and excluded from an export file. 
+The following outlines special resource IDs, used to map to data, and resource types, used to outline what's included and excluded from an export file.
 
 {:.alert .alert-primary}
 **Note**: The [Insomnia Importers Package](https://github.com/kong/insomnia/tree/develop/packages/insomnia-importers) has support for migrating older export versions to the latest, as well as supporting external formats like HAR, Postman, Swagger/OpenAPI, and Curl. If you want to contribute new formats, feel free to submit a pull request to the [insomnia-importers](https://www.npmjs.com/package/insomnia-importers) NPM package.


### PR DESCRIPTION
### Summary

Add Export Data and Import Data sections to Import and Export Data page.

### Reason

Goes into more detail for users seeking that information.

### Testing

Export Data: https://insomnia-docs-git-docu-2107-teaminsomnia.vercel.app/insomnia/import-export-data#export-data
Import Data: https://insomnia-docs-git-docu-2107-teaminsomnia.vercel.app/insomnia/import-export-data#import-data