### PR TITLE
Use API to redirect to latest github release for Inso

### DIFF
--- a/docs/inso-cli/install.md
+++ b/docs/inso-cli/install.md
@@ -9,7 +9,7 @@ Install Inso CLI using our single executable commands for your operating system,
 
 ## Install Single Executable
 
-Inso CLI can be downloaded and run as a single executable on MacOS, Windows, and Linux. Download the release artifacts from [GitHub Releases](https://github.com/Kong/insomnia/releases/tag/lib%402.4.1).
+Inso CLI can be downloaded and run as a single executable on MacOS, Windows, and Linux. Download the release artifacts from [GitHub Releases](https://api.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable).
 
 To use our single executable options, select your operating system.
 
@@ -22,7 +22,7 @@ To use our single executable options, select your operating system.
 </nav>
 <div class="tab-content" id="nav-tabContent">
   <div class="tab-pane fade show active" id="nav-home" role="tabpanel" aria-labelledby="nav-home-tab">
-  On MacOS, download the MacOS zip or pkg from <a href="https://github.com/Kong/insomnia/releases/tag/lib%402.4.1">GitHub</a> or use Homebrew. If you use the pkg option, click through the prompt window as you normally would when downloading an app from the internet.
+  On MacOS, download the MacOS zip or pkg from <a href="https://api.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable">GitHub</a> or use Homebrew. If you use the pkg option, click through the prompt window as you normally would when downloading an app from the internet.
 <br/><br/>
 <h4>Extract the Zip File</h4>
 If you download the zip file, extract it from Finder or with the following command:
@@ -40,14 +40,14 @@ Check that Inso CLI was properly installed with the following command:
 <pre class="highlight"><code>inso --version</code></pre>
   </div>
   <div class="tab-pane fade" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">
-  On Windows, download the Windows zip file from <a href="https://github.com/Kong/insomnia/releases/tag/lib%402.4.1">GitHub</a>. Then, extract the executable using Windows Explorer, or via the following command:
+  On Windows, download the Windows zip file from <a href="https://api.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable">GitHub</a>. Then, extract the executable using Windows Explorer, or via the following command:
   <br/><br/>
 <pre class="highlight"><code>tar -xf inso-windows-2.4.1.zip</code></pre>
 Check that Inso CLI was properly installed with the following command:
 <br/><br/>
 <pre class="highlight"><code>./inso --version</code></pre>
   </div>
-  <div class="tab-pane fade" id="nav-contact" role="tabpanel" aria-labelledby="nav-contact-tab">On Linux, download the Linux tar file from <a href="https://github.com/Kong/insomnia/releases/tag/lib%402.4.1">GitHub</a>. Extract the file by using the following command:
+  <div class="tab-pane fade" id="nav-contact" role="tabpanel" aria-labelledby="nav-contact-tab">On Linux, download the Linux tar file from <a href="https://api.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable">GitHub</a>. Extract the file by using the following command:
   <br/><br/>
   <pre class="highlight"><code>tar -xf inso-linux-2.4.1.tar.xz</code></pre>
   Check that Inso CLI was properly installed with the following command:

--- a/docs/inso-cli/install.md
+++ b/docs/inso-cli/install.md
@@ -9,7 +9,7 @@ Install Inso CLI using our single executable commands for your operating system,
 
 ## Install Single Executable
 
-Inso CLI can be downloaded and run as a single executable on MacOS, Windows, and Linux. Download the release artifacts from [GitHub Releases](https://api.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable).
+Inso CLI can be downloaded and run as a single executable on MacOS, Windows, and Linux. Download the release artifacts from [GitHub Releases](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable).
 
 To use our single executable options, select your operating system.
 
@@ -22,7 +22,7 @@ To use our single executable options, select your operating system.
 </nav>
 <div class="tab-content" id="nav-tabContent">
   <div class="tab-pane fade show active" id="nav-home" role="tabpanel" aria-labelledby="nav-home-tab">
-  On MacOS, download the MacOS zip or pkg from <a href="https://api.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable">GitHub</a> or use Homebrew. If you use the pkg option, click through the prompt window as you normally would when downloading an app from the internet.
+  On MacOS, download the MacOS zip or pkg from <a href="https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable">GitHub</a> or use Homebrew. If you use the pkg option, click through the prompt window as you normally would when downloading an app from the internet.
 <br/><br/>
 <h4>Extract the Zip File</h4>
 If you download the zip file, extract it from Finder or with the following command:
@@ -40,14 +40,14 @@ Check that Inso CLI was properly installed with the following command:
 <pre class="highlight"><code>inso --version</code></pre>
   </div>
   <div class="tab-pane fade" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">
-  On Windows, download the Windows zip file from <a href="https://api.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable">GitHub</a>. Then, extract the executable using Windows Explorer, or via the following command:
+  On Windows, download the Windows zip file from <a href="https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable">GitHub</a>. Then, extract the executable using Windows Explorer, or via the following command:
   <br/><br/>
 <pre class="highlight"><code>tar -xf inso-windows-2.4.1.zip</code></pre>
 Check that Inso CLI was properly installed with the following command:
 <br/><br/>
 <pre class="highlight"><code>./inso --version</code></pre>
   </div>
-  <div class="tab-pane fade" id="nav-contact" role="tabpanel" aria-labelledby="nav-contact-tab">On Linux, download the Linux tar file from <a href="https://api.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable">GitHub</a>. Extract the file by using the following command:
+  <div class="tab-pane fade" id="nav-contact" role="tabpanel" aria-labelledby="nav-contact-tab">On Linux, download the Linux tar file from <a href="https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable">GitHub</a>. Extract the file by using the following command:
   <br/><br/>
   <pre class="highlight"><code>tar -xf inso-linux-2.4.1.tar.xz</code></pre>
   Check that Inso CLI was properly installed with the following command:


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Using the API to redirect to the latest github release means we don't need to specify a specific version in the link and update after every release. Yay!

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Closes INS-1087

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

Click the updated links, they should redirect to the latest stable github release for Inso (currently 2.4.1).

https://insomnia-docs-git-feature-ins-1087-update-i-2c9c46-teaminsomnia.vercel.app/inso-cli/install
