### PR TITLE
Fix minor typo in GraphQL Queries doc page

### DIFF
--- a/docs/insomnia/graphql-queries.md
+++ b/docs/insomnia/graphql-queries.md
@@ -9,7 +9,7 @@ category-url: built-in-features
 
 ## Using GraphQL
 
-Creating a GraphQL request in Insomnia is easy. It can be done be either selecting the GraphQL request type during creation or by changing the body type of an existing request using the body menu.
+Creating a GraphQL request in Insomnia is easy. It can be done by either selecting the GraphQL request type during creation or by changing the body type of an existing request using the body menu.
 
 Once this is done, you can fill in the query and variables section of the query.
 


### PR DESCRIPTION
"It can be done ~~be~~ by either selecting the GraphQL request type"

### Summary
Minor typo: ~~be~~ by

### Reason
Improve readability

### Testing
Go to https://docs.insomnia.rest/insomnia/graphql-queries and check that the typo is fixed
