### PR TITLE
spelling error in graphql-for-openapi.md

### DIFF
--- a/docs/insomnia/graphql-for-openapi.md
+++ b/docs/insomnia/graphql-for-openapi.md
@@ -23,7 +23,7 @@ paths:
       operationId: 'graphql'
       responses:
         '200':
-          description: 'Successfull Query'
+          description: 'Successful Query'
           content: 
             application/json:
               schema:


### PR DESCRIPTION
### Summary
Successfull => Successful

### Reason
very minor spelling error in documentation

### Testing
no tests required, merely a spelling error