### PR TITLE
Add Inso CLI on Docker doc

### DIFF
--- a/docs/_data/main-nav.yaml
+++ b/docs/_data/main-nav.yaml
@@ -146,6 +146,8 @@ toc:
             url: /inso-cli/cli-command-reference/OAS-spec.yml
       - title: Configuration
         url: /inso-cli/configuration
+      - title: Inso CLI on Docker
+        url: /inso-cli/inso-on-docker
       - title: Continuous Integration
         url: /inso-cli/continuous-integration
   - title: Work with Other Kong Products

--- a/docs/inso-cli/inso-on-docker.md
+++ b/docs/inso-cli/inso-on-docker.md
@@ -50,7 +50,9 @@ docker run -v $HOME/.config/Insomnia:/var/temp -it --rm kong/inso:latest run tes
 docker run -v /mnt/c/Users/<your_username>/AppData/Roaming/Insomnia:/var/temp -it --rm kong/inso:latest run test --src /var/temp
 ```
 
-- Mount the folder where you keep an Insomnia v4 export:
+### Mount v4 export folder
+
+Mount the folder where you keep an Insomnia v4 export:
 
 ```shell
 cd <some-folder>

--- a/docs/inso-cli/inso-on-docker.md
+++ b/docs/inso-cli/inso-on-docker.md
@@ -7,7 +7,7 @@ category-url: inso-cli
 
 ## Pull `kong/inso`
 
-To pull the latest `kong/inso` Docker image:
+Pull the latest `kong/inso` Docker image:
 
 ```shell
 docker pull kong/inso:latest

--- a/docs/inso-cli/inso-on-docker.md
+++ b/docs/inso-cli/inso-on-docker.md
@@ -35,7 +35,9 @@ docker run -it --rm -v $(pwd):/var/temp kong/inso:latest run test -w /var/temp
 docker run -it --rm -v $(pwd):/var/temp kong/inso:latest generate config -w /var/temp -f json
 ```
 
-- Mount the Insomnia Application Data folder:
+## Mount Application Data folder 
+
+Mount the Insomnia Application Data folder:
 
 ```shell
 # On macOS:

--- a/docs/inso-cli/inso-on-docker.md
+++ b/docs/inso-cli/inso-on-docker.md
@@ -17,7 +17,7 @@ All available tags can be found on Inso-CLI's [Docker Hub page](https://hub.dock
 
 ## Run Inso CLI commands
 
-To run Insomnia specs in `kong/inso` container, mount the specs folder on your host machine to a `/var/temp` folder on the container. Examples:
+To run Insomnia specs in `kong/inso` container, mount the specs folder on your host machine to a `/var/temp` folder in the container. See the following sections for some examples.
 
 - Mount an Insomnia git sync repository folder to a folder on the container:
 

--- a/docs/inso-cli/inso-on-docker.md
+++ b/docs/inso-cli/inso-on-docker.md
@@ -42,8 +42,10 @@ Mount the Insomnia Application Data folder:
 ```shell
 # On macOS:
 docker run -v $HOME/Library/Application\ Support/Insomnia:/var/temp -it --rm kong/inso:latest run test --src /var/temp
+
 # On Linux:
 docker run -v $HOME/.config/Insomnia:/var/temp -it --rm kong/inso:latest run test --src /var/temp
+
 # On Windows (using Docker for Windows and WSL):
 docker run -v /mnt/c/Users/<your_username>/AppData/Roaming/Insomnia:/var/temp -it --rm kong/inso:latest run test --src /var/temp
 ```

--- a/docs/inso-cli/inso-on-docker.md
+++ b/docs/inso-cli/inso-on-docker.md
@@ -19,7 +19,11 @@ All available tags can be found on Inso-CLI's [Docker Hub page](https://hub.dock
 
 To run Insomnia specs in `kong/inso` container, mount the specs folder on your host machine to a `/var/temp` folder in the container. See the following sections for some examples.
 
-- Mount an Insomnia git sync repository folder to a folder on the container:
+## Examples
+
+### Mount git sync repo
+
+Mount an Insomnia git sync repository folder to a folder in the container:
 
 ```shell
 cd <your-git-sync-repo-folder>

--- a/docs/inso-cli/inso-on-docker.md
+++ b/docs/inso-cli/inso-on-docker.md
@@ -1,0 +1,50 @@
+---
+layout: article-detail
+title:  Inso CLI on Docker
+category: "Inso CLI"
+category-url: inso-cli
+---
+
+## Pull `kong/inso`
+
+To pull the latest `kong/inso` Docker image:
+
+```shell
+docker pull kong/inso:latest
+```
+
+All available tags can be found on Inso-CLI's [Docker Hub page](https://hub.docker.com/r/kong/inso/tags).
+
+## Run Inso CLI commands
+
+To run Insomnia specs in `kong/inso` container, mount the specs folder on your host machine to a `/var/temp` folder on the container. Examples:
+
+- Mount an Insomnia git sync repository folder to a folder on the container:
+
+```shell
+cd <your-git-sync-repo-folder>
+
+# Run Unit Tests
+docker run -it --rm -v $(pwd):/var/temp kong/inso:latest run test -w /var/temp
+
+# Generate Kong Declarative config
+docker run -it --rm -v $(pwd):/var/temp kong/inso:latest generate config -w /var/temp -f json
+```
+
+- Mount the Insomnia Application Data folder:
+
+```shell
+# On macOS:
+docker run -v $HOME/Library/Application\ Support/Insomnia:/var/temp -it --rm kong/inso:latest run test --src /var/temp
+# On Linux:
+docker run -v $HOME/.config/Insomnia:/var/temp -it --rm kong/inso:latest run test --src /var/temp
+# On Windows (using Docker for Windows and WSL):
+docker run -v /mnt/c/Users/<your_username>/AppData/Roaming/Insomnia:/var/temp -it --rm kong/inso:latest run test --src /var/temp
+```
+
+- Mount the folder where you keep an Insomnia v4 export:
+
+```shell
+cd <some-folder>
+docker run -it --rm -v $(pwd):/var/temp kong/inso:latest run test -w /var/temp/Insomnia_YYYY-MM-DD.json
+```


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Adds information about [Inso CLI on Docker](https://hub.docker.com/r/kong/inso), available in beta, and will be introduced in `2022.4.0` GA.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->
- Clone insomnia-docs repo
- Run `make setup run`
- Visit `localhost:4000`


![Screenshot 2022-06-06 at 18 47 51](https://user-images.githubusercontent.com/11976836/172216639-23d0cd35-6467-442b-ac4c-45640384b326.png)

