### PR TITLE
Fix subscriptions - typo fix in the subscriptions page

### DIFF
--- a/docs/insomnia/subscriptions.md
+++ b/docs/insomnia/subscriptions.md
@@ -24,5 +24,5 @@ The subscription sign up page will open.  Choose the plan type you want, enter y
 ### Difference between Individual vs Teams
 On the Insomnia Individual plan, Insomnia Sync is enabled for all devices that have Insomnia installed and in which the user has logged in with their Insomnia Account.  This will allow an Insomnia User to [create snapshots and branches](https://docs.insomnia.rest/insomnia/insomnia-sync) of their Insomnia Collections and ensure that all of their devices can stay up to date with the latest and greatest of their personal collections.
 
-With Insomnia Teams, Insomnia Users can add other Insomnia Users into their team and share and sync their Collecdtions between all members of their teams.  Each member of the team will still be able to sync the team collections between an unlimited number of devices like in the Insomnia Plus plan.  In addition, team members can sync collections between each other.  
+With Insomnia Teams, Insomnia Users can add other Insomnia Users into their team and share and sync their Collections between all members of their teams.  Each member of the team will still be able to sync the team collections between an unlimited number of devices like in the Insomnia Plus plan.  In addition, team members can sync collections between each other.  
 


### PR DESCRIPTION
### Summary
A fix of typo in the subscription page. 😊

### Reason
"Collection" is misspelled.

### Testing
Tested locally.
