### PR TITLE
Update proxy documentation to include SOCKS4 and SOCKS5 support

### DIFF
--- a/docs/_data/main-nav.yaml
+++ b/docs/_data/main-nav.yaml
@@ -122,8 +122,8 @@ toc:
         url: /insomnia/run-in-insomnia-button
       - title: Key Maps
         url: /insomnia/key-maps
-      - title: HTTP(S) Proxy
-        url: /insomnia/http-proxy
+      - title: Proxy
+        url: /insomnia/proxy
       - title: Insomnia Configuration File
         url: /insomnia/insomnia-config-file
   - title: Plugins

--- a/docs/insomnia/http-proxy.md
+++ b/docs/insomnia/http-proxy.md
@@ -1,14 +1,26 @@
 ---
 layout: article-detail
-title:  HTTP(S) Proxy
+title:  Proxy
 category: "Get Started"
 category-url: get-started
 ---
 
-Insomnia does not automatically detect system-wide proxy settings. A proxy can be set up manually. Set your HTTP or HTTPS proxy server and reroute all future requests through that server by accessing Preferences via the cog icon > **General** > **HTTP Network Proxy**.
+Insomnia does not automatically detect system-wide proxy settings. A proxy can be set up manually. Set your HTTP, HTTPS, SOCKS4 or SOCKS5 proxy server and reroute all future requests through that server by accessing Preferences via the cog icon > **General** > **HTTP Network Proxy**.
 
 {:.alert .alert-primary}
 **Note**: Proxy server settings apply to all traffic going through the Insomnia application, and cannot be restricted to entities such as Collections and individual requests.
+
+Example usage of HTTP or HTTPS proxy
+
+```bash
+http://localhost:8005
+```
+
+For SOCKS4 or SOCKS5 proxy, one of the following prefixes should be used before the hostname depending on the verion (**socks4h://**, **socks5h://**)
+
+```bash
+socks5h://localhost:8005
+```
 
 You can also add a comma-separated list of hostnames to the **No Proxy** box and they will be exempt from going through the proxy server.
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -51,7 +51,7 @@
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://docs.insomnia.rest/insomnia/http-proxy</loc>
+  <loc>https://docs.insomnia.rest/insomnia/proxy</loc>
   <lastmod>2022-04-20T14:38:46+00:00</lastmod>
   <priority>0.64</priority>
 </url>

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -87,7 +87,7 @@
     { "source": "/article/176-(.*)", "destination": "/insomnia/graphql-queries", "permanent": false },
     { "source": "/article/188-(.*)", "destination": "/insomnia/grpc", "permanent": false },
     { "source": "/article/189-(.*)", "destination": "/insomnia/faq#technical-questions", "permanent": false },
-    { "source": "/article/179-(.*)", "destination": "/insomnia/http-proxy", "permanent": false },
+    { "source": "/article/179-(.*)", "destination": "/insomnia/proxy", "permanent": false },
     { "source": "/article/158-(.*)", "destination": "/insomnia/security-standards", "permanent": false },
     { "source": "/article/192-(.*)", "destination": "/insomnia/unit-testing", "permanent": false },
     { "source": "/article/156-(.*)", "destination": "/insomnia/install", "permanent": false },


### PR DESCRIPTION
### Summary
Updated proxy documentation to include SOCKS4 and SOCKS5 support.

### Reason
The documentation was missing information about SOCKS4 and SOCKS5 proxy support in Insomnia. This update adds that information to provide more complete and accurate documentation for users.

Take a look a this previous issue: https://github.com/Kong/insomnia/issues/1085

### Testing
This change can be tested by reviewing the updated documentation and verifying that it accurately reflects the proxy options available in Insomnia. Additionally, the SOCKS4 and SOCKS5 proxy support can be tested within the Insomnia application to ensure that it works as expected. I tested it by making the changes to the file, reviewing the updated content, and verifying that the SOCKS4 and SOCKS5 proxy options work in Insomnia.
