### PR TITLE
Correct data path on windows

### DIFF
--- a/docs/insomnia/application-data.md
+++ b/docs/insomnia/application-data.md
@@ -7,7 +7,7 @@ category-url: support
 
 Insomnia stores data in the following location, depending on the platform:
 
-* `%APPDATA%\Roaming\Insomnia` on **Windows**
+* `%APPDATA%\Insomnia` on **Windows**
 * `$XDG_CONFIG_HOME/Insomnia` or `~/.config/Insomnia` on **Linux**
 * `~/Library/Application\ Support/Insomnia` on **macOS**
 

--- a/docs/insomnia/faq.md
+++ b/docs/insomnia/faq.md
@@ -72,7 +72,7 @@ Sometimes, if you make a request that returns a lot of data, Insomnia will becom
 
     You can find the application data folder in the Help menu. If the help menu is not accessible, here are the default paths for each operating system.
 
-    `%APPDATA%\Roaming` on Windows
+    `%APPDATA%` on Windows
     `$XDG_CONFIG_HOME` or `~/.config` on Linux
     `~/Library/Application\ Support` on macOS
 
@@ -113,7 +113,7 @@ The import/export feature acts similarly to copying files in a filesystem. If th
 
 Insomnia stores data in Electron's appData directory, which differs depending on platform. The local database is distributed across files with the name `insomnia.${resourceName}.db`.
 
-* `%APPDATA%\Roaming\Insomnia` on **Windows**
+* `%APPDATA%\Insomnia` on **Windows**
 * `XDG_CONFIG_HOME/Insomnia` or `~/.config/Insomnia` on **Linux**
 * `~/Library/Application\ Support/Insomnia` on **macOS**
 
@@ -123,7 +123,7 @@ The app data directory can also be shown by navigating to **Help** > **Show App 
 
 Insomnia stores logs in the following location, depending on the platform:
 
-* `%APPDATA%\Roaming\Insomnia\logs` on Windows
+* `%APPDATA%\Insomnia\logs` on Windows
 * `$XDG_CONFIG_HOME/Insomnia/logs` or `~/.config/Insomnia/logs` on Linux
 * `~/Library/Logs/Insomnia` on macOS
 

--- a/docs/insomnia/introduction-to-plugins.md
+++ b/docs/insomnia/introduction-to-plugins.md
@@ -29,7 +29,7 @@ To disable an Insomnia plugin, go to **Preferences**, represented by the cog ico
 To remove an Insomnia Plugin permanently, navigate to the following location on your machine and delete the plugin folder manually:
 
 * MacOS:   `~/Library/Application Support/Insomnia/plugins/` (escaped version: `~/Library/Application\ Support/Insomnia/plugins/`)
-* Windows: `%APPDATA%\Roaming\Insomnia\plugins\`
+* Windows: `%APPDATA%\Insomnia\plugins\`
 * Linux:   `$XDG_CONFIG_HOME/Insomnia/plugins/` or `~/.config/Insomnia/plugins/`
 
 You can always [re-add the plugin](#add-a-plugin) if it's still available.
@@ -43,7 +43,7 @@ An Insomnia plugin is a NodeJS module that is placed in a specific directory tha
 In order for Insomnia to recognize your plugin as an Insomnia plugin, your files must live in the following locations:
 
 * MacOS:   `~/Library/Application Support/Insomnia/plugins/` (escaped version: `~/Library/Application\ Support/Insomnia/plugins/`)
-* Windows: `%APPDATA%\Roaming\Insomnia\plugins\`
+* Windows: `%APPDATA%\Insomnia\plugins\`
 * Linux:   `$XDG_CONFIG_HOME/Insomnia/plugins/` or `~/.config/Insomnia/plugins/`
 
 {:.alert .alert-primary}

--- a/docs/insomnia/migrate-from-designer.md
+++ b/docs/insomnia/migrate-from-designer.md
@@ -27,7 +27,7 @@ When migration begins, a backup of your data will be created at <app-data-dir>/i
 
 `app-data-dir` is stored in the following location:
 
-* `%APPDATA%\Roaming\Insomnia` on Windows
+* `%APPDATA%\Insomnia` on Windows
 * `$XDG_CONFIG_HOME/Insomnia` or `~/.config/Insomnia` on Linux
 * `~/Library/Application\ Support/Insomnia` on macOS
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
On windows, the environment variable `APPDATA` already points to AppData\Roaming, so the path to insomnia's data would actually be `%APPDATA%\Insomnia` instead of the already documented `%APPDATA%\Roaming\Insomnia`

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
So people in the future can find the path easier

### Testing
<!-- How can your reviewers test your change? How did you test it? -->
Tried the original path documented, it didn't exist
Then I tried the path I provided, it actually did exist