### PR TITLE
Replaced broken link with Login/Signup link.

### DIFF
--- a/docs/insomnia/accounts.md
+++ b/docs/insomnia/accounts.md
@@ -10,7 +10,7 @@ category-url: insomnia-accounts
 
 ### Signing up from the Insomnia Desktop Application 
 You can Sign Up for Insomnia by clicking on the **Sign Up** button on the top bar of the Insomnia Desktop App, on the right hand side.
-[Login and Signup button](!/assets/login-signup.png)
+[Login and Signup button](https://app.insomnia.rest/app/authorize)
 
 When you click on **Sign Up**, you will be redirected to the [insomnia website](https://app.insomnia.rest/app/signup) to finish the process.
 


### PR DESCRIPTION
In Accounts page,  Login and Signup button text was assigned with a link which path was an Image (assets/login-signup.png) and was broken but now replaced with original Login/Signup link.
