### PR TITLE
docs: update socks proxy schemes

### DIFF
--- a/docs/insomnia/proxy.md
+++ b/docs/insomnia/proxy.md
@@ -16,7 +16,7 @@ Example usage of HTTP or HTTPS proxy
 http://localhost:8005
 ```
 
-For SOCKS4 or SOCKS5 proxy, one of the following prefixes should be used before the hostname depending on the verion (**socks4h://**, **socks5h://**)
+For SOCKS4 or SOCKS5 proxy, one of the following prefixes should be used before the hostname depending on the verion (**socks4://**, **socks4a://**, **socks5://**, **socks5h://**)
 
 ```bash
 socks5h://localhost:8005


### PR DESCRIPTION
### Summary
There is no scheme called `socks4h`.

### Reason
I don't understand how Electron use proxies, But According the [curl documentation](https://curl.se/libcurl/c/CURLOPT_PROXY.html) socks proxy support the following four schemes:

* socks4
* socks4a
* socks5
* socks5h

### Testing

I tried specifying the above four schemes in Insomnia's proxy settings, and with any of these schemes, I was able to use socks proxy as expected.
When specifying the scheme `socks4h`, Insomnia cannot use the socks proxy, and all requests will fail.

