### PR TITLE
Update context-object-reference.md

### DIFF
--- a/docs/insomnia/context-object-reference.md
+++ b/docs/insomnia/context-object-reference.md
@@ -237,18 +237,13 @@ interface AppContext {
 
 ## context.data
 
-The data context contains helpers related to importing and exporting Insomnia workspaces.
+The data context contains helpers related to importing and exporting Insomnia workspaces. The import function will import the contents into a new workspace on the same project you are current at.
 
 ```ts
-interface ImportOptions {
-    workspaceId?: string;
-    workspaceScope?: 'design' | 'collection';
-}
-
 interface DataContext {
     import: {
-        uri(uri: string, options?: ImportOptions): Promise<void>;
-        raw(text: string, options?: ImportOptions): Promise<void>;
+        uri(uri: string): Promise<void>;
+        raw(text: string): Promise<void>;
     },
     export: {
         insomnia(options?: { 


### PR DESCRIPTION
Updating documentation so it reflects the correct arguments to use the import feature.

### Summary
As mentioned on the PR [#6044](https://github.com/Kong/insomnia/pull/6044), the ImportOptions interface does not exists anymore and the import feature consider only the project structure, instead of the workspace to import the contents.

### Reason
The documentation is outdated since it does not reflect the behaviour of the import feature.

### Testing
It does not require testing, since it is a documentation update.
