### PR TITLE
feat(slsa): Use release tag starting from 9.3.0 for slsa examples

### DIFF
--- a/docs/inso-cli/provenance/verify-binary-provenance.md
+++ b/docs/inso-cli/provenance/verify-binary-provenance.md
@@ -19,8 +19,8 @@ For the complete example, you need the same details as the minimal example, as w
 | Shorthand | Description | Example Value |
 |---|---|---|
 | `<repo>` | GitHub repository | `insomnia` |
-| `version` | Artifact version to download | `9.3.0-beta.4` |
-| `<binary-files>` | Single / Space separated isno binary files | `inso-*-9.3.0-beta.4.{pkg,tar.xz,zip}` |
+| `version` | Artifact version to download | `9.3.0` |
+| `<binary-files>` | Single / Space separated isno binary files | `inso-*-9.3.0.{pkg,tar.xz,zip}` |
 | `<provenance-file>` | Binary provenance file | `inso-provenance.intoto.jsonl` |
 
 Because Kong uses GitHub Actions to build and release, Kong also uses GitHub's OIDC identity to generate build provenance for binary artifacts, which is why many of these details are GitHub-related.
@@ -33,9 +33,9 @@ For both examples, you need to:
 
 1. Ensure `slsa-verifier` is installed.
 
-2. [Download Inso Binaries](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=beta) with file pattern `inso-*.{pkg,tar.xz,zip}`
+2. [Download Inso Binaries](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable) with file pattern `inso-*.{pkg,tar.xz,zip}`
 
-3. [Download Inso Binary Provenance Attestation](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=beta) with pattern `inso-provenance.intoto.jsonl`
+3. [Download Inso Binary Provenance Attestation](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable) with pattern `inso-provenance.intoto.jsonl`
 
 {:.important .no-icon}
 > The GitHub owner is case-sensitive (`Kong/insomnia` vs `kong/insomnia`).
@@ -61,7 +61,7 @@ slsa-verifier verify-artifact \
    --print-provenance \
    --provenance-path 'inso-provenance.intoto.jsonl' \
    --source-uri 'github.com/Kong/insomnia' \
-   inso-*-9.3.0-beta.4.{zip,tar.xz,pkg}
+   inso-*-9.3.0.{zip,tar.xz,pkg}
 ```
 
 The command will print "Verified SLSA provenance" if successful:
@@ -82,7 +82,7 @@ slsa-verifier verify-artifact \
    --print-provenance \
    --provenance-path '<provenance-file>' \
    --source-uri 'github.com/Kong/<repo>' \
-   --build-workflow-input 'version=9.3.0-beta.4' \
+   --build-workflow-input 'version=9.3.0' \
    <binary-files>
 ```
 
@@ -93,6 +93,6 @@ slsa-verifier verify-artifact \
    --print-provenance \
    --provenance-path 'inso-provenance.intoto.jsonl' \
    --source-uri 'github.com/Kong/insomnia' \
-   --build-workflow-input 'version=9.3.0-beta.4' \
-   inso-*-9.3.0-beta.4.{zip,tar.xz,pkg}
+   --build-workflow-input 'version=9.3.0' \
+   inso-*-9.3.0.{zip,tar.xz,pkg}
 ```

--- a/docs/inso-cli/provenance/verify-image-provenance.md
+++ b/docs/inso-cli/provenance/verify-image-provenance.md
@@ -24,7 +24,7 @@ For the complete example, you need the same details as the minimal example, as w
 | `<repo>` | GitHub repository | `insomnia` |
 | `<workflow name>` | GitHub workflow name | `Release Publish` |
 | `<workflow trigger>` | Github workflow trigger name | `workflow_dispatch` |
-| `<version>` | version | `9.3.0-beta.4` |
+| `<version>` | version | `9.3.0` |
 
 Because Kong uses GitHub Actions to build and release, Kong also uses GitHub's OIDC identity to generate build provenance for container images, which is why many of these details are GitHub-related.
 
@@ -43,7 +43,7 @@ For both examples, you need to:
 4. Parse the `<manifest_digest>` for the image using `regctl`.
 
    ```sh
-   IMAGE_DIGEST=$(regctl manifest digest kong/inso:9.3.0-beta.4)
+   IMAGE_DIGEST=$(regctl manifest digest kong/inso:9.3.0)
    ```
 
 5. Set the `COSIGN_REPOSITORY` environment variable:
@@ -73,7 +73,7 @@ Here's the same example using sample values instead of placeholders:
 
 ```sh
 cosign verify-attestation \
-   kong/inso:9.3.0-beta.4@${IMAGE_DIGEST} \
+   kong/inso:9.3.0@${IMAGE_DIGEST} \
    --type='slsaprovenance' \
    --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
    --certificate-identity-regexp='^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$'
@@ -103,7 +103,7 @@ Here's the same example using sample values instead of placeholders:
 
 ```sh
 slsa-verifier verify-image \
-   kong/inso:9.3.0-beta.4@${IMAGE_DIGEST} \
+   kong/inso:9.3.0@${IMAGE_DIGEST} \
    --print-provenance \
    --provenance-repository kong/notary \
    --source-uri 'github.com/Kong/insomnia'
@@ -137,7 +137,7 @@ Here's the same example using sample values instead of placeholders:
 
 ```sh
 cosign verify-attestation \
-   kong/inso:9.3.0-beta.4@${IMAGE_DIGEST} \
+   kong/inso:9.3.0@${IMAGE_DIGEST} \
    --type='slsaprovenance' \
    --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
    --certificate-identity-regexp='^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
@@ -155,7 +155,7 @@ slsa-verifier verify-image \
    <image>:<tag>@${IMAGE_DIGEST} \
    --print-provenance \
    --provenance-repository kong/notary \
-   --build-workflow-input 'version=9.3.0-beta.4' \
+   --build-workflow-input 'version=9.3.0' \
    --source-uri 'github.com/Kong/<repo>'
 ```
 
@@ -163,9 +163,9 @@ Here's the same example using sample values instead of placeholders:
 
 ```sh
 slsa-verifier verify-image \
-   kong/inso:9.3.0-beta.4@${IMAGE_DIGEST} \
+   kong/inso:9.3.0@${IMAGE_DIGEST} \
    --print-provenance \
    --provenance-repository kong/notary \
-   --build-workflow-input 'version=9.3.0-beta.4' \
+   --build-workflow-input 'version=9.3.0' \
    --source-uri 'github.com/Kong/insomnia'
 ```

--- a/docs/inso-cli/sbom.md
+++ b/docs/inso-cli/sbom.md
@@ -11,7 +11,7 @@ We are generating SBOMs for both inso binaries and docker container images.
 
 ## Download SBOM
 
-1. Navigate to Insomnia [GitHub Releases](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=beta)
+1. Navigate to Insomnia [GitHub Releases](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable)
 
 2. Download the below SBOMs as needed:
 

--- a/docs/inso-cli/verify-signed-images.md
+++ b/docs/inso-cli/verify-signed-images.md
@@ -42,7 +42,7 @@ For both examples, you need to:
 
 4. Parse the image manifest digest
     ```sh
-   IMAGE_DIGEST=$(regctl manifest digest kong/inso:9.3.0-beta.4)
+   IMAGE_DIGEST=$(regctl manifest digest kong/inso:9.3.0)
    ```
 
 {:.important .no-icon}
@@ -63,7 +63,7 @@ Here's the same example using sample values instead of placeholders:
 
 ```sh
 cosign verify \
-   kong/inso:9.3.0-beta.4@${IMAGE_DIGEST} \
+   kong/inso:9.3.0@${IMAGE_DIGEST} \
    --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
    --certificate-identity-regexp='https://github.com/Kong/insomnia/.github/workflows/release-publish.yml'
 ```
@@ -83,7 +83,7 @@ Here's the same example using sample values instead of placeholders:
 
 ```sh
 cosign verify \
-   kong/inso:9.3.0-beta.4@${IMAGE_DIGEST} \
+   kong/inso:9.3.0@${IMAGE_DIGEST} \
    --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
    --certificate-identity-regexp='https://github.com/Kong/insomnia/.github/workflows/release-publish.yml' \
    -a repo='Kong/insomnia' \

--- a/docs/insomnia/sbom.md
+++ b/docs/insomnia/sbom.md
@@ -9,6 +9,6 @@ A software bill of materials (SBOM) is an inventory of all software components (
 
 ## Download SBOM
 
-1. Navigate to Insomnia [GitHub Releases](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.app&channel=beta)
+1. Navigate to Insomnia [GitHub Releases](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.app&channel=stable)
 
 2. Download the `sbom.spdx.json` and `sbom.cyclonedx.json` SBOM files for Insomnia App

--- a/docs/insomnia/verify-binary-provenance.md
+++ b/docs/insomnia/verify-binary-provenance.md
@@ -19,8 +19,8 @@ For the complete example, you need the same details as the minimal example, as w
 | Shorthand | Description | Example Value |
 |---|---|---|
 | `<repo>` | GitHub repository | `insomnia` |
-| `version` | Artifact version to download | `9.3.0-beta.4` |
-| `<binary-files>` | Single / Space separated isnomnia binary files | `Insomnia.Core-9.3.0-beta.4.{snap,tar.gz,zip,rpm,dmg,deb,exe,AppImage}` |
+| `version` | Artifact version to download | `9.3.0` |
+| `<binary-files>` | Single / Space separated isnomnia binary files | `Insomnia.Core-9.3.0.{snap,tar.gz,zip,rpm,dmg,deb,exe,AppImage}` |
 | `<provenance-file>` | Binary provenance file | `inso-provenance.intoto.jsonl` |
 
 Because Kong uses GitHub Actions to build and release, Kong also uses GitHub's OIDC identity to generate build provenance for binary artifacts, which is why many of these details are GitHub-related.
@@ -33,9 +33,9 @@ For both examples, you need to:
 
 1. Ensure `slsa-verifier` is installed.
 
-2. [Download Insomnia Core Application Binaries](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.app&channel=beta) with file pattern `Insomnia.Core-<version>.{snap,tar.gz,zip,rpm,dmg,deb,exe,AppImage}`
+2. [Download Insomnia Core Application Binaries](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.app&channel=stable) with file pattern `Insomnia.Core-<version>.{snap,tar.gz,zip,rpm,dmg,deb,exe,AppImage}`
 
-3. [Download Insomnia Binary Provenance Attestation](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.app&channel=beta) with pattern `insomnia-provenance.intoto.jsonl`
+3. [Download Insomnia Binary Provenance Attestation](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.app&channel=stable) with pattern `insomnia-provenance.intoto.jsonl`
 
 {:.important .no-icon}
 > The GitHub owner is case-sensitive (`Kong/insomnia` vs `kong/insomnia`).
@@ -61,7 +61,7 @@ slsa-verifier verify-artifact \
    --print-provenance \
    --provenance-path 'insomnia-provenance.intoto.jsonl' \
    --source-uri 'github.com/Kong/insomnia' \
-   Insomnia.Core-9.3.0-beta.4.{snap,tar.gz,zip,rpm,dmg,deb,AppImage,exe}
+   Insomnia.Core-9.3.0.{snap,tar.gz,zip,rpm,dmg,deb,AppImage,exe}
 ```
 
 The command will print "Verified SLSA provenance" if successful:
@@ -82,7 +82,7 @@ slsa-verifier verify-artifact \
    --print-provenance \
    --provenance-path '<provenance-file>' \
    --source-uri 'github.com/Kong/<repo>' \
-   --build-workflow-input 'version=9.3.0-beta.4' \
+   --build-workflow-input 'version=9.3.0' \
    <binary-files>
 ```
 
@@ -93,6 +93,6 @@ slsa-verifier verify-artifact \
    --print-provenance \
    --provenance-path 'insomnia-provenance.intoto.jsonl' \
    --source-uri 'github.com/Kong/insomnia' \
-   --build-workflow-input 'version=9.3.0-beta.4' \
-   Insomnia.Core-9.3.0-beta.4.{snap,tar.gz,zip,rpm,dmg,deb,AppImage,exe}
+   --build-workflow-input 'version=9.3.0' \
+   Insomnia.Core-9.3.0.{snap,tar.gz,zip,rpm,dmg,deb,AppImage,exe}
 ```


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
-   **Merge** after `9.3.0` release
- Use official release tag `9.3.0` for slsa examples to verify image signatures, binary provenance and image provenance for insomnia and inso artifacts

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->
