### PR TITLE
fix: broken link in insomnia cli docs

### DIFF
--- a/docs/inso-cli/cli-command-reference/inso-lint-spec.md
+++ b/docs/inso-cli/cli-command-reference/inso-lint-spec.md
@@ -21,7 +21,7 @@ Lint the given specification, the user will be prompted to select a specificatio
 
 At the moment Inso CLI uses Spectral's default `oas` Ruleset Definition. For more information refer to the [OpenAPI ruleset reference documentation](https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md).
 
-> For custom linting, refer to the [Custom Linting](custom-linting) document.
+> For custom linting, refer to the [Custom Linting](inso-custom-linting) document.
 
 ## Global Flags
 


### PR DESCRIPTION
### Summary
Fixed the broken link to the custom linting page.

### Reason
Issue reported in Slack

### Testing
<!-- How can your reviewers test your change? How did you test it? -->
