### PR TITLE
doc: update github sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Add a new page if you are adding documentation for a new topic. Don't add a new 
 ### Keep it simple
 
 * Don't add unnecessary and excessive packages.
-* **Use screenshots very sparingly**. And if you add a screenshot, ensure it has descriptive alt text and a short description underneath. See [Introduction to Insomnia](/insomnia/get-started) for an example.  
+* **Use screenshots very sparingly**. And if you add a screenshot, ensure it has descriptive alt text and a short description underneath. See [Introduction to Insomnia](/insomnia/get-started) for an example.
 * Use the Oxford Comma to prevent any misinterpretation.
 * Use Vanilla JS where needed. No need to add jQuery.
 * For icons, use [Google Icons](https://fonts.google.com/icons). This means we don't have to download an entire library to use just a few icons.

--- a/docs/inso-cli/continuous-integration.md
+++ b/docs/inso-cli/continuous-integration.md
@@ -7,7 +7,7 @@ category-url: inso-cli
 
 Inso CLI has been designed to run in a Continuous Integration (CI) environment, disables prompts, and provides exit codes to pass or fail the CI workflow.
 
-An example workflow run in Github Actions does the following:
+An example workflow run in GitHub Actions does the following:
 
 1. Checks out branch
 2. Downloads [Setup Inso GitHub Action](https://github.com/marketplace/actions/setup-inso)

--- a/docs/inso-cli/provenance/verify-image-provenance.md
+++ b/docs/inso-cli/provenance/verify-image-provenance.md
@@ -23,7 +23,7 @@ For the complete example, you need the same details as the minimal example, as w
 |---|---|---|
 | `<repo>` | GitHub repository | `insomnia` |
 | `<workflow name>` | GitHub workflow name | `Release Publish` |
-| `<workflow trigger>` | Github workflow trigger name | `workflow_dispatch` |
+| `<workflow trigger>` | GitHub workflow trigger name | `workflow_dispatch` |
 | `<version>` | version | `9.3.0` |
 
 Because Kong uses GitHub Actions to build and release, Kong also uses GitHub's OIDC identity to generate build provenance for container images, which is why many of these details are GitHub-related.

--- a/docs/inso-cli/verify-signed-images.md
+++ b/docs/inso-cli/verify-signed-images.md
@@ -18,11 +18,11 @@ For the complete example, you need the same details as the minimal example, as w
 
 | Shorthand | Description | Example Value |
 |---|---|---|
-| `<repo>` | Github repository | `insomnia` |
-| `<workflow filename>` | Github workflow filename | `release-publish.yml` |
-| `<workflow name>` | Github workflow name | `Release Publish` |
+| `<repo>` | GitHub repository | `insomnia` |
+| `<workflow filename>` | GitHub workflow filename | `release-publish.yml` |
+| `<workflow name>` | GitHub workflow name | `Release Publish` |
 
-Because Kong uses Github Actions to build and release, Kong also uses Github's OIDC identity to sign images, which is why many of these details are Github-related.
+Because Kong uses GitHub Actions to build and release, Kong also uses GitHub's OIDC identity to sign images, which is why many of these details are GitHub-related.
 
 ## Examples
 
@@ -46,7 +46,7 @@ For both examples, you need to:
    ```
 
 {:.important .no-icon}
-> Github owner is case-sensitive (`Kong/insomnia` vs `kong/insomnia`).
+> GitHub owner is case-sensitive (`Kong/insomnia` vs `kong/insomnia`).
 
 ### Minimal example
 

--- a/docs/insomnia/after-response-script.md
+++ b/docs/insomnia/after-response-script.md
@@ -90,4 +90,4 @@ There are some differences to be aware about:
 - `CollectionVariables` is mapped to `baseEnvironment` in Insomnia.
 - Deprecated `postman` interfaces are not supported yet, such as `postman.setEnvironmentVariable`.
 
-If you notice any incompatibility issues, please report these by create a [new issue on Github](https://github.com/kong/insomnia/issues).
+If you notice any incompatibility issues, please report these by create a [new issue on GitHub](https://github.com/kong/insomnia/issues).

--- a/docs/insomnia/git-sync.md
+++ b/docs/insomnia/git-sync.md
@@ -47,10 +47,12 @@ When configuring a remote repository, you can chose to connect with GitHub or Gi
 
 1. Open a document in Insomnia, then click **Setup Git Sync** in the upper right corner of the Insomnia app.
 2. Click "Configure Repository", then open the GitHub tab.
-3. Click **Authenticate with GitHub**.
-4. Click on **Continue**. If the browser has already been authenticated with Github, the page will say "Successfully authenticated Insomnia".
-5. You might be prompted to continue by your browser through the Insomnia app via  "Choose Application" box.  If you are not, you can follow the instructions on the page to complete Github account authentication with the Insomnia App.
-6. You can now clone any repository from GitHub! Copy the HTTPS URI for the GitHub repository you want to connect to and paste it into the "GitHub URI" field.
+3. Click **Authenticate with GitHub App**. Your web browser should opened to the Insomnia website.
+4. Click on **Continue**.
+5. You might be prompted to continue by your browser through the Insomnia app via  "Choose Application" box.  If you are not, you can follow the instructions on the page to complete GitHub account authentication with the Insomnia App.
+6. You can now clone repositories that the GitHub App has access to! Search for the repository you want to connect to and click **Clone**.
+
+NOTE: If you cannot find the repository you want to connect to, you will need to ask the repository or organization owner to install the [Insomnia Desktop GitHub App](https://github.com/apps/insomnia-desktop).
 
 ### Set up a remote repository with GitLab
 
@@ -80,9 +82,10 @@ When configuring a remote repository, you can chose to connect with GitHub or Gi
 
 Find instructions on how to create a personal access token or app password on the following platforms:
 
-* [Github](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-  * For public repos, scope at least [`public_repo`](https://github.com/settings/tokens/new?description=insomnia-git-sync&scopes=public_repo) when creating your token.
-  * For private repos, scope at least [`repo`](https://github.com/settings/tokens/new?description=insomnia-git-sync&scopes=repo) when creating your token.
+* [GitHub](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+  * Ensure that the token has the `user:email` scope in order to correctly associate commits with your GitHub account.
+  * For public repos, select [`public_repo`](https://github.com/settings/tokens/new?description=insomnia-git-sync&scopes=public_repo,user:email) when creating your token.
+  * For private repos, select [`repo`](https://github.com/settings/tokens/new?description=insomnia-git-sync&scopes=repo,user:email) when creating your token.
 * [Gitlab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
   * For public and private GitLab repos, scope at least `api` when creating your personal access token.
 * [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/)

--- a/docs/insomnia/pre-request-script.md
+++ b/docs/insomnia/pre-request-script.md
@@ -24,7 +24,7 @@ There are some differences to be aware about:
 - `CollectionVariables` is mapped to `baseEnvironment` in Insomnia.
 - Deprecated `postman` interfaces are not supported yet, such as `postman.setEnvironmentVariable`.
 
-If you notice any incompatibility issues, please report these by create a [new issue on Github](https://github.com/kong/insomnia/issues).
+If you notice any incompatibility issues, please report these by create a [new issue on GitHub](https://github.com/kong/insomnia/issues).
 
 ## Examples
 


### PR DESCRIPTION
With Insomnia 10.3, we're switching over to using a GitHub app instead of OAuth for git syncing.

This updates the descriptions of some steps in the flow