### PR TITLE
chore: update the repo name from insomina to insomnia-ee

### DIFF
--- a/docs/inso-cli/provenance/verify-binary-provenance.md
+++ b/docs/inso-cli/provenance/verify-binary-provenance.md
@@ -18,7 +18,7 @@ For the complete example, you need the same details as the minimal example, as w
 
 | Shorthand | Description | Example Value |
 |---|---|---|
-| `<repo>` | GitHub repository | `insomnia` |
+| `<repo>` | GitHub repository | `insomnia-ee` |
 | `version` | Artifact version to download | `9.3.0` |
 | `<binary-files>` | Single / Space separated isno binary files | `inso-*-9.3.0.{pkg,tar.xz,zip}` |
 | `<provenance-file>` | Binary provenance file | `inso-provenance.intoto.jsonl` |
@@ -38,7 +38,7 @@ For both examples, you need to:
 3. [Download Inso Binary Provenance Attestation](https://updates.insomnia.rest/downloads/release/latest?app=com.insomnia.inso&channel=stable) with pattern `inso-provenance.intoto.jsonl`
 
 {:.important .no-icon}
-> The GitHub owner is case-sensitive (`Kong/insomnia` vs `kong/insomnia`).
+> The GitHub owner is case-sensitive (`Kong/insomnia-ee` vs `kong/insomnia-ee`).
 
 ### Minimal example
 
@@ -60,7 +60,7 @@ Here's the same example using sample values instead of placeholders:
 slsa-verifier verify-artifact \
    --print-provenance \
    --provenance-path 'inso-provenance.intoto.jsonl' \
-   --source-uri 'github.com/Kong/insomnia' \
+   --source-uri 'github.com/Kong/insomnia-ee' \
    inso-*-9.3.0.{zip,tar.xz,pkg}
 ```
 
@@ -92,7 +92,7 @@ Here's the same example using sample values instead of placeholders:
 slsa-verifier verify-artifact \
    --print-provenance \
    --provenance-path 'inso-provenance.intoto.jsonl' \
-   --source-uri 'github.com/Kong/insomnia' \
+   --source-uri 'github.com/Kong/insomnia-ee' \
    --build-workflow-input 'version=9.3.0' \
    inso-*-9.3.0.{zip,tar.xz,pkg}
 ```

--- a/docs/inso-cli/provenance/verify-image-provenance.md
+++ b/docs/inso-cli/provenance/verify-image-provenance.md
@@ -21,7 +21,7 @@ For the complete example, you need the same details as the minimal example, as w
 
 | Shorthand | Description | Example Value |
 |---|---|---|
-| `<repo>` | GitHub repository | `insomnia` |
+| `<repo>` | GitHub repository | `insomnia-ee` |
 | `<workflow name>` | GitHub workflow name | `Release Publish` |
 | `<workflow trigger>` | GitHub workflow trigger name | `workflow_dispatch` |
 | `<version>` | version | `9.3.0` |
@@ -53,7 +53,7 @@ For both examples, you need to:
    ```
 
 {:.important .no-icon}
-> The GitHub owner is case-sensitive (`Kong/insomnia` vs `kong/insomnia`).
+> The GitHub owner is case-sensitive (`Kong/insomnia-ee` vs `kong/insomnia-ee`).
 
 ### Minimal example
 
@@ -106,7 +106,7 @@ slsa-verifier verify-image \
    kong/inso:9.3.0@${IMAGE_DIGEST} \
    --print-provenance \
    --provenance-repository kong/notary \
-   --source-uri 'github.com/Kong/insomnia'
+   --source-uri 'github.com/Kong/insomnia-ee'
 ```
 
 The command will print "Verified SLSA provenance" if successful:
@@ -141,7 +141,7 @@ cosign verify-attestation \
    --type='slsaprovenance' \
    --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
    --certificate-identity-regexp='^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
-   --certificate-github-workflow-repository='Kong/insomnia' \
+   --certificate-github-workflow-repository='Kong/insomnia-ee' \
    --certificate-github-workflow-name='Release Publish' \
    --certificate-github-workflow-trigger='workflow_dispatch'
 ```
@@ -167,5 +167,5 @@ slsa-verifier verify-image \
    --print-provenance \
    --provenance-repository kong/notary \
    --build-workflow-input 'version=9.3.0' \
-   --source-uri 'github.com/Kong/insomnia'
+   --source-uri 'github.com/Kong/insomnia-ee'
 ```


### PR DESCRIPTION
update the repo name from `insomina` to `insomnia-ee` for both binary and image provenance verification
