### PR TITLE
fix: Pin all external gitHub actions to their corresponding commit SHAs

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run docsearch for Insomnia Docs
-      uses: darrenjennings/algolia-docsearch-action@master
+      uses: darrenjennings/algolia-docsearch-action@75b0f6d28d82eff3dd76f57a96a99490df11a250 # master
       with:
         algolia_api_key: ${{ secrets.ALGOLIA_API_KEY }}
         algolia_application_id: ${{ secrets.ALGOLIA_APPLICATION_ID }}

--- a/.github/workflows/build-docs-pdf.yml
+++ b/.github/workflows/build-docs-pdf.yml
@@ -10,7 +10,7 @@ jobs:
 
       # Configure Ruby to build Jekyll site
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1
         with:
           ruby-version: 2.7.2
       - name: Ruby gem cache


### PR DESCRIPTION
### Summary
Replace branch reference with commit SHA in external github actions

### Reason
This is to prevent any compromise of the upstream github action(similar to the recent [tj-actions/changed-files](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) action vulnerability) from affecting the repo